### PR TITLE
Replaced usage of Activator.CreateInstance with factory methods

### DIFF
--- a/Common/CommunityToolkit.Labs.Core.SourceGenerators/Metadata/ToolkitSampleMetadata.cs
+++ b/Common/CommunityToolkit.Labs.Core.SourceGenerators/Metadata/ToolkitSampleMetadata.cs
@@ -15,6 +15,7 @@ namespace CommunityToolkit.Labs.Core.SourceGenerators.Metadata;
 /// <param name="DisplayName">The display name for this sample page.</param>
 /// <param name="Description">The description for this sample page.</param>
 /// <param name="SampleControlType">A type that can be used to construct an instance of the sample control.</param>
+/// <param name="SampleControlFactory">A factory method that returns a new instance of the control.</param>
 /// <param name="SampleOptionsPaneType">
 /// The control type for the sample page's options pane.
 /// Constructor should have exactly one parameter that can be assigned to the control type (<see cref="SampleControlType"/>).
@@ -26,5 +27,7 @@ public sealed record ToolkitSampleMetadata(
         string DisplayName,
         string Description,
         Type SampleControlType,
+        Func<object> SampleControlFactory,
         Type? SampleOptionsPaneType = null,
+        Func<object, object>? SampleOptionsPaneFactory = null,
         IEnumerable<IGeneratedToolkitSampleOptionViewModel>? GeneratedSampleOptions = null);

--- a/Common/CommunityToolkit.Labs.Core.SourceGenerators/ToolkitSampleMetadataGenerator.cs
+++ b/Common/CommunityToolkit.Labs.Core.SourceGenerators/ToolkitSampleMetadataGenerator.cs
@@ -232,13 +232,15 @@ public static class ToolkitSampleRegistry
 
     private static string MetadataToRegistryCall(ToolkitSampleRecord metadata)
     {
-        var sampleOptionsParam = metadata.SampleOptionsAssemblyQualifiedName is null ? "null" : $"typeof({metadata.SampleOptionsAssemblyQualifiedName})";
         var categoryParam = $"{nameof(ToolkitSampleCategory)}.{metadata.Category}";
         var subcategoryParam = $"{nameof(ToolkitSampleSubcategory)}.{metadata.Subcategory}";
-        var containingClassTypeParam = $"typeof({metadata.SampleAssemblyQualifiedName})";
+        var sampleControlTypeParam = $"typeof({metadata.SampleAssemblyQualifiedName})";
+        var sampleControlFactoryParam = $"() => new {metadata.SampleAssemblyQualifiedName}()";
         var generatedSampleOptionsParam = $"new {typeof(IGeneratedToolkitSampleOptionViewModel).FullName}[] {{ {string.Join(", ", BuildNewGeneratedSampleOptionMetadataSource(metadata).ToArray())} }}";
+        var sampleOptionsParam = metadata.SampleOptionsAssemblyQualifiedName is null ? "null" : $"typeof({metadata.SampleOptionsAssemblyQualifiedName})";
+        var sampleOptionsPaneFactoryParam = metadata.SampleOptionsAssemblyQualifiedName is null ? "null" : $"x => new {metadata.SampleOptionsAssemblyQualifiedName}(({metadata.SampleAssemblyQualifiedName})x)";
 
-        return @$"yield return new {typeof(ToolkitSampleMetadata).FullName}({categoryParam}, {subcategoryParam}, ""{metadata.DisplayName}"", ""{metadata.Description}"", {containingClassTypeParam}, {sampleOptionsParam}, {generatedSampleOptionsParam});";
+        return @$"yield return new {typeof(ToolkitSampleMetadata).FullName}({categoryParam}, {subcategoryParam}, ""{metadata.DisplayName}"", ""{metadata.Description}"", {sampleControlTypeParam}, {sampleControlFactoryParam}, {sampleOptionsParam}, {sampleOptionsPaneFactoryParam}, {generatedSampleOptionsParam});";
     }
 
     private static IEnumerable<string> BuildNewGeneratedSampleOptionMetadataSource(ToolkitSampleRecord sample)

--- a/Common/CommunityToolkit.Labs.Shared/AppLoadingView.xaml.cs
+++ b/Common/CommunityToolkit.Labs.Shared/AppLoadingView.xaml.cs
@@ -87,6 +87,15 @@ namespace CommunityToolkit.Labs.Shared
 
             if (samplePages.Length == 1)
             {
+                // Individual samples are UserControls,
+                // but multi-sample view and grouped sample views should be a Page.
+                // TODO: Remove after creating grouped-sample view.
+                if (!samplePages[0].SampleControlType.IsSubclassOf(typeof(Page)))
+                {
+                    Window.Current.Content = (UIElement)samplePages[0].SampleControlFactory();
+                    return;
+                }
+
                 ScheduleNavigate(samplePages[0].SampleControlType);
                 return;
             }
@@ -103,15 +112,6 @@ namespace CommunityToolkit.Labs.Shared
         {
             DispatcherQueue.GetForCurrentThread().TryEnqueue(() =>
             {
-                // Individual samples are UserControls,
-                // but multi-sample view and grouped sample views should be a Page.
-                // TODO: Remove after creating grouped-sample view.
-                if (!type.IsSubclassOf(typeof(Page)))
-                {
-                    Window.Current.Content = (UIElement)Activator.CreateInstance(type);
-                    return;
-                }
-
 #if __WASM__
                 Frame.Navigate(type, param);
 #else

--- a/Common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/Common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -126,12 +126,12 @@ namespace CommunityToolkit.Labs.Shared.Renderers
             XamlCode = await GetMetadataFileContents(Metadata, "xaml");
             CSharpCode = await GetMetadataFileContents(Metadata, "xaml.cs");
 
-            SampleControlInstance = (UIElement)Activator.CreateInstance(Metadata.SampleControlType);
+            SampleControlInstance = (UIElement)Metadata.SampleControlFactory();
 
             // Custom control-based sample options.
             if (Metadata.SampleOptionsPaneType is not null)
             {
-                SampleOptionsPaneInstance = (UIElement)Activator.CreateInstance(Metadata.SampleOptionsPaneType, SampleControlInstance);
+                SampleOptionsPaneInstance = (UIElement)Metadata.SampleOptionsPaneFactory(SampleControlInstance);
             }
 
             // Source generater-based sample options


### PR DESCRIPTION
This PR closes #39

### Summary
- Adds factory methods to source generators that
    - Return a constructed instance of the sample page
    - Return a constructed instance of a sample page's options page.
- Replaces usage of `Activator.CreateInstance` with the new factory methods.
- Tested and working under UWP / WASM.

This also pre-emptively fixes an issue on Android where `Activator.CreateInstance()` threw a `TargetInvocationException`. 