### PR TITLE
Rename CommunityToolkit.Labs.Uwp.UI.CanvasLayout to CommunityToolkit.Labs.WinUI.CanvasLayout

### DIFF
--- a/CommunityToolkit.Labs.Uwp/CommunityToolkit.Labs.Uwp.csproj
+++ b/CommunityToolkit.Labs.Uwp/CommunityToolkit.Labs.Uwp.csproj
@@ -25,9 +25,9 @@
       <Project>{a14189c0-39a8-4fbe-bf86-a78a94654c48}</Project>
       <Name>CanvasLayout.Sample</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Labs\CanvasLayout\src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj">
+    <ProjectReference Include="..\Labs\CanvasLayout\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj">
       <Project>{fe19fff0-6ab6-4fc7-bfdf-b6499153dcd5}</Project>
-      <Name>CommunityToolkit.Labs.Uwp.UI.CanvasLayout</Name>
+      <Name>CommunityToolkit.Labs.WinUI.CanvasLayout</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="../Common/Labs.Uwp.props" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <CommonTags>$(CommonTags);UWP;Labs;Experimental</CommonTags>
+    <CommonTags>$(CommonTags);UWP;WinUI;Uno;Labs;Experimental</CommonTags>
     <PackageTags Condition="'$(PackageTags)' != ''">$(CommonTags);$(PackageTags)</PackageTags>
     <PackageTags Condition="'$(PackageTags)' == ''">$(CommonTags)</PackageTags>
   </PropertyGroup>

--- a/Labs/CanvasLayout/CanvasLayout.sln
+++ b/Labs/CanvasLayout/CanvasLayout.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Labs.Uwp.UI.CanvasLayout", "src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj", "{1C029CC0-BB45-45FF-AD34-086EC4840DB0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Labs.WinUI.CanvasLayout", "src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj", "{1C029CC0-BB45-45FF-AD34-086EC4840DB0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CanvasLayout.Uwp", "samples\CanvasLayout.Uwp\CanvasLayout.Uwp.csproj", "{3BAAC2DA-7124-460E-A9A9-13138843CD57}"
 EndProject

--- a/Labs/CanvasLayout/samples/CanvasLayout.Sample/CanvasLayout.Sample.csproj
+++ b/Labs/CanvasLayout/samples/CanvasLayout.Sample/CanvasLayout.Sample.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Common\CommunityToolkit.Labs.Core.SourceGenerators\CommunityToolkit.Labs.Core.SourceGenerators.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj">
+    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj">
       <AdditionalProperties>WinUITarget=$(WinUITarget)</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>

--- a/Labs/CanvasLayout/samples/CanvasLayout.Sample/SampleThree/SamplePage3.xaml
+++ b/Labs/CanvasLayout/samples/CanvasLayout.Sample/SampleThree/SamplePage3.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="using:CanvasLayout.Sample.SampleThree"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:labs="using:CommunityToolkit.Labs.Uwp"
+    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">

--- a/Labs/CanvasLayout/samples/CanvasLayout.Sample/SampleThree/SamplePage3.xaml.cs
+++ b/Labs/CanvasLayout/samples/CanvasLayout.Sample/SampleThree/SamplePage3.xaml.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using CommunityToolkit.Labs.Core.SourceGenerators;
 using CommunityToolkit.Labs.Core.SourceGenerators.Attributes;
-using CommunityToolkit.Labs.Uwp;
+using CommunityToolkit.Labs.WinUI;
 
 #if !WINAPPSDK
 using Windows.Foundation;

--- a/Labs/CanvasLayout/samples/CanvasLayout.Uwp/CanvasLayout.Uwp.csproj
+++ b/Labs/CanvasLayout/samples/CanvasLayout.Uwp/CanvasLayout.Uwp.csproj
@@ -17,9 +17,9 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj">
-      <Project>{1c029cc0-bb45-45ff-ad34-086ec4840db0}</Project>
-      <Name>CommunityToolkit.Labs.Uwp.UI.CanvasLayout</Name>
+    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj">
+      <Project>{FE19FFF0-6AB6-4FC7-BFDF-B6499153DCD5}</Project>
+      <Name>CommunityToolkit.Labs.WinUI.CanvasLayout</Name>
     </ProjectReference>
     <ProjectReference Include="..\CanvasLayout.Sample\CanvasLayout.Sample.csproj">
       <Project>{a14189c0-39a8-4fbe-bf86-a78a94654c48}</Project>

--- a/Labs/CanvasLayout/samples/CanvasLayout.Wasm/CanvasLayout.Wasm.csproj
+++ b/Labs/CanvasLayout/samples/CanvasLayout.Wasm/CanvasLayout.Wasm.csproj
@@ -7,7 +7,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj" />
+    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj" />
     <ProjectReference Include="..\CanvasLayout.Sample\CanvasLayout.Sample.csproj" />
   </ItemGroup>
 </Project>

--- a/Labs/CanvasLayout/samples/CanvasLayout.WinAppSdk/CanvasLayout.WinAppSdk.csproj
+++ b/Labs/CanvasLayout/samples/CanvasLayout.WinAppSdk/CanvasLayout.WinAppSdk.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CanvasLayout.Sample\CanvasLayout.Sample.csproj" />
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj" />
+    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Labs/CanvasLayout/src/CanvasLayout.cs
+++ b/Labs/CanvasLayout/src/CanvasLayout.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
 
-namespace CommunityToolkit.Labs.Uwp
+namespace CommunityToolkit.Labs.WinUI
 {
     public class CanvasLayout : VirtualizingLayout
     {

--- a/Labs/CanvasLayout/src/CommunityToolkit.Labs.WinUI.CanvasLayout.csproj
+++ b/Labs/CanvasLayout/src/CommunityToolkit.Labs.WinUI.CanvasLayout.csproj
@@ -2,11 +2,11 @@
   <Import Project="../../../Common/Labs.MultiTarget.props" />
 
   <PropertyGroup>
-    <RootNamespace>CommunityToolkit.Labs.Uwp</RootNamespace>
+    <RootNamespace>CommunityToolkit.Labs.WinUI</RootNamespace>
   </PropertyGroup>
   
   <PropertyGroup>
-    <PackageId>CommunityToolkit.Labs.Uwp.CanvasLayout</PackageId>
+    <PackageId>CommunityToolkit.Labs.WinUI.CanvasLayout</PackageId>
     <Description>
       This package contains a CanvasLayout Layout for ItemsRepeater.
     </Description>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,9 +1,9 @@
 
-# 🧪 Community Toolkit Labs - UWP 🧪
+# 🧪 Community Toolkit Labs for Windows 🧪
 
-Welcome to the home of Toolkit Labs experiments for UWP. Find out more about Toolkit Labs in our [Wiki here](https://aka.ms/toolkit/wiki/labs). It includes more about our motivations for having this space as well as how to setup the NuGet feed required to easily use experiments found in this repo.
+Welcome to the home of Toolkit Labs experiments for Windows (built on top of WinUI 2, WinUI 3, and [Uno Platform](https://platform.uno)). Find out more about Toolkit Labs in our [Wiki here](https://aka.ms/toolkit/wiki/labs). It includes more about our motivations for having this space as well as how to setup the NuGet feed required to easily use experiments found in this repo.
 
-This is the starting place for all new features to make it into the Windows Community Toolkit. It is a useful prototyping space as well as a space to work collaboratively on polishing a feature. This allows a final PR into the main Toolkit repo to go as smoothly as possible once a feature is ready to go.
+This is the starting place for all new features to make it into the [Windows Community Toolkit](https://aka.ms/wct). It is a useful prototyping space as well as a space to work collaboratively on polishing a feature. This allows a final PR into the main Toolkit repo to go as smoothly as possible once a feature is ready to go.
 
 ## Sample App
 

--- a/Toolkit.Labs.All.sln
+++ b/Toolkit.Labs.All.sln
@@ -22,7 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CanvasLayout", "CanvasLayou
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CanvasLayout.Uwp", "Labs\CanvasLayout\samples\CanvasLayout.Uwp\CanvasLayout.Uwp.csproj", "{3BAAC2DA-7124-460E-A9A9-13138843CD57}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Labs.Uwp.UI.CanvasLayout", "Labs\CanvasLayout\src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj", "{FE19FFF0-6AB6-4FC7-BFDF-B6499153DCD5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Labs.WinUI.CanvasLayout", "Labs\CanvasLayout\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj", "{FE19FFF0-6AB6-4FC7-BFDF-B6499153DCD5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CanvasLayout.Sample", "Labs\CanvasLayout\samples\CanvasLayout.Sample\CanvasLayout.Sample.csproj", "{A14189C0-39A8-4FBE-BF86-A78A94654C48}"
 EndProject

--- a/Toolkit.Labs.Wasm.sln
+++ b/Toolkit.Labs.Wasm.sln
@@ -18,7 +18,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Labs.Wasm"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CanvasLayout", "CanvasLayout", "{86E3CC4D-1359-4249-9C5B-C193BF65633D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Labs.Uwp.UI.CanvasLayout", "Labs\CanvasLayout\src\CommunityToolkit.Labs.Uwp.UI.CanvasLayout.csproj", "{FE19FFF0-6AB6-4FC7-BFDF-B6499153DCD5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommunityToolkit.Labs.WinUI.CanvasLayout", "Labs\CanvasLayout\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj", "{FE19FFF0-6AB6-4FC7-BFDF-B6499153DCD5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CanvasLayout.Sample", "Labs\CanvasLayout\samples\CanvasLayout.Sample\CanvasLayout.Sample.csproj", "{A14189C0-39A8-4FBE-BF86-A78A94654C48}"
 EndProject

--- a/Windows.Toolkit.Common.props
+++ b/Windows.Toolkit.Common.props
@@ -7,10 +7,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Copyright>(c) .NET Foundation and Contributors.  All rights reserved.</Copyright>
-    <PackageProjectUrl>https://github.com/CommunityToolkit/Labs-UWP</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/CommunityToolkit/Labs-UWP/releases</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/CommunityToolkit/Labs-Windows</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/CommunityToolkit/Labs-Windows/releases</PackageReleaseNotes>
     <PackageIcon>Icon.png</PackageIcon>
-    <PackageIconUrl>https://raw.githubusercontent.com/CommunityToolkit/Labs-UWP/main/nuget.png</PackageIconUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/CommunityToolkit/Labs-Windows/main/nuget.png</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #27

Want to simplify and align our naming to expected final conventions of using `CommunityToolkit.Labs.WinUI.*` for experiments.

Tested in the All solution, but ran into #41 for the others (though have updated them here compared to last time I tried this).