### PR TITLE
Add Initial CI File for validating samples and pushing packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         
       # Build All Packages - TODO: Detect experiments
       - name: pack CanvasLayout
-        working-directory: ./Labs/CanvasLayout/
+        working-directory: ./Labs/CanvasLayout/src
         run: msbuild -t:pack /p:Configuration=Release /p:DebugType=Portable
 
       # Push Packages to our DevOps Artifacts Feed                       


### PR DESCRIPTION
Built off of #42, just testing adding a CI file workflow...

Needs more work of course, but just seeing what happens with trying to build things to get info for the direction to take.