### PR TITLE
Moved all TargetFramework values to new props file

### DIFF
--- a/Common/Labs.MultiTarget.props
+++ b/Common/Labs.MultiTarget.props
@@ -1,22 +1,23 @@
 <Project InitialTargets="ValidateWinUITarget">
+  <Import Project="Labs.TargetFrameworks.props" />
 
   <PropertyGroup>
     <WinUITarget Condition="'$(WinUITarget)' == ''">2.x</WinUITarget>
 
-    <TargetFrameworks>netstandard2.0;uap10.0.19041;net6.0-macos;net6.0-maccatalyst;xamarinios10;monoandroid11.0;net6.0-windows10.0.19041.0</TargetFrameworks>
-    <IsUno Condition="'$(TargetFramework)' != 'uap10.0.19041' AND '$(TargetFramework)' != 'net6.0-windows10.0.19041.0'">True</IsUno>
+    <TargetFrameworks>$(WasmLibTargetFramework);$(WpfLibTargetFramework);$(LinuxLibTargetFramework);$(UwpTargetFramework);$(WinAppSdkTargetFramework);$(MacOSLibTargetFramework);$(iOSLibTargetFramework);$(AndroidLibTargetFramework);</TargetFrameworks>
+    <IsUno Condition="'$(TargetFramework)' != '$(UwpTargetFramework)' AND '$(TargetFramework)' != '$(WinAppSdkTargetFramework)'">True</IsUno>
 
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net6.0-windows10.0.19041.0'">WINAPPSDK</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == '$(WinAppSdkTargetFramework)'">WINAPPSDK</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0-windows10.0.19041.0' OR '$(TargetFramework)' == 'uap10.0.19041'">
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(WinAppSdkTargetFramework)' OR '$(TargetFramework)' == '$(UwpTargetFramework)'">
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
   </PropertyGroup>
 
-  <Target Name="ValidateWinUITarget" Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <Target Name="ValidateWinUITarget" Condition="'$(IsUno)' == 'true'">
     <Error Condition="'$(WinUITarget)' != '2.x' AND '$(WinUITarget)' != '3.x'"
            Text="Property 'WinUITarget' contained an invalid value '$(WinUITarget)'. A value of '2.x' or '3.x' is expected when building an Uno target."/>
   </Target>
@@ -30,8 +31,8 @@
     <PackageReference Condition="'$(IsUno)' == 'True' AND '$(WinUITarget)' == '2.x'" Include="Uno.UI" Version="4.0.11"/>
     <PackageReference Condition="'$(IsUno)' == 'True' AND '$(WinUITarget)' == '3.x'" Include="Uno.WinUI" Version="4.0.11"/>
 
-    <PackageReference Condition="'$(TargetFramework)' == 'uap10.0.19041'" Include="Microsoft.UI.Xaml" Version="2.7.0" />
-    <PackageReference Condition="'$(TargetFramework)' == 'net6.0-windows10.0.19041.0'" Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' == '$(UwpTargetFramework)'" Include="Microsoft.UI.Xaml" Version="2.7.0" />
+    <PackageReference Condition="'$(TargetFramework)' == '$(WinAppSdkTargetFramework)'" Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
 
   <!-- Source generator props -->

--- a/Common/Labs.TargetFrameworks.props
+++ b/Common/Labs.TargetFrameworks.props
@@ -1,0 +1,17 @@
+<Project>
+    <PropertyGroup>
+        <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
+        <WinAppSdkTargetFramework>net6.0-windows10.0.19041.0</WinAppSdkTargetFramework>
+        
+        <WasmHeadTargetFramework>net5.0</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework>net5.0</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework>netcoreapp3.1</WpfHeadTargetFramework>
+        
+        <WasmLibTargetFramework>netstandard2.0</WasmLibTargetFramework>
+        <LinuxLibTargetFramework>netstandard2.0</LinuxLibTargetFramework>
+        <AndroidLibTargetFramework>monoandroid11.0</AndroidLibTargetFramework>
+        <MacOSLibTargetFramework>xamarinmac20</MacOSLibTargetFramework>
+        <iOSLibTargetFramework>xamarinios10</iOSLibTargetFramework>
+        <WpfLibTargetFramework>netstandard2.0</WpfLibTargetFramework>
+    </PropertyGroup>
+</Project>

--- a/Common/Labs.Uwp.props
+++ b/Common/Labs.Uwp.props
@@ -1,12 +1,13 @@
 <Project>
   <!-- Common properties needed for a labs project (UWP) -->
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.TargetFrameworks.props" />
 
   <PropertyGroup>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <IncludeContentInPack>false</IncludeContentInPack>
-    <TargetFramework>uap10.0.17763</TargetFramework>
+    <TargetFramework>$(UwpTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Common/Labs.Wasm.props
+++ b/Common/Labs.Wasm.props
@@ -1,8 +1,10 @@
 <Project>
   <!-- Common properties needed for a labs project (Wasm) -->
+  <Import Project="$(RepositoryDirectory)Common\Labs.TargetFrameworks.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(WasmHeadTargetFramework)</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Common/Labs.WinAppSdk.props
+++ b/Common/Labs.WinAppSdk.props
@@ -1,11 +1,12 @@
 <Project>
   <!-- Common properties needed for a labs project (WinAppSdk) -->
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.TargetFrameworks.props" />
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>$(WinAppSdkTargetFramework)</TargetFramework>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>

--- a/Labs/CanvasLayout/samples/CanvasLayout.Sample/CanvasLayout.Sample.csproj
+++ b/Labs/CanvasLayout/samples/CanvasLayout.Sample/CanvasLayout.Sample.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="MSBuild.Sdk.Extras/3.0.23">
-  <Import Project="../../../../Common/Labs.MultiTarget.props" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.MultiTarget.props" />
   
   <ItemGroup>
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />

--- a/Labs/CanvasLayout/src/CommunityToolkit.Labs.WinUI.CanvasLayout.csproj
+++ b/Labs/CanvasLayout/src/CommunityToolkit.Labs.WinUI.CanvasLayout.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="MSBuild.Sdk.Extras/3.0.23">
-  <Import Project="../../../Common/Labs.MultiTarget.props" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.MultiTarget.props" />
 
   <PropertyGroup>
     <RootNamespace>CommunityToolkit.Labs.WinUI</RootNamespace>

--- a/Platforms/CommunityToolkit.Labs.Skia.Gtk/CommunityToolkit.Labs.Skia.Gtk.csproj
+++ b/Platforms/CommunityToolkit.Labs.Skia.Gtk/CommunityToolkit.Labs.Skia.Gtk.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(RepositoryDirectory)\Common\Labs.SampleRefs.props" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.SampleRefs.props" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.TargetFrameworks.props" />
   <Import Project="$(RepositoryDirectory)Common\Labs.Head.props" />
 
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(LinuxHeadTargetFramework)</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\CommunityToolkit.Labs.UWP')">

--- a/Platforms/CommunityToolkit.Labs.Skia.WPF.Host/CommunityToolkit.Labs.Skia.Wpf.Host.csproj
+++ b/Platforms/CommunityToolkit.Labs.Skia.WPF.Host/CommunityToolkit.Labs.Skia.Wpf.Host.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <Import Project="$(RepositoryDirectory)Common\Labs.TargetFrameworks.props" />
+
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(WpfHeadTargetFramework)</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/Platforms/CommunityToolkit.Labs.Skia.WPF/CommunityToolkit.Labs.Skia.WPF.csproj
+++ b/Platforms/CommunityToolkit.Labs.Skia.WPF/CommunityToolkit.Labs.Skia.WPF.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(RepositoryDirectory)\Common\Labs.SampleRefs.props" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.SampleRefs.props" />
+  <Import Project="$(RepositoryDirectory)Common\Labs.TargetFrameworks.props" />
   <Import Project="$(RepositoryDirectory)Common\Labs.Head.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(WpfLibTargetFramework)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />


### PR DESCRIPTION
Closes #45 
- **Adds a new `Labs.TargetFrameworks.props` file**, containing TargetFramework values for all platform heads and libraries.
- **Removes all hardcoded `<TargetFramework>`** definitions to use the values in the new props file.
- **Tested** and builds successfully (pending a fix for MacOS/iOS)