### PR TITLE
Fixed MacOS and iOS projects not building properly

### DIFF
--- a/Common/Labs.Head.props
+++ b/Common/Labs.Head.props
@@ -17,8 +17,9 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepositoryDirectory)Common\CommunityToolkit.Labs.Core.SourceGenerators\CommunityToolkit.Labs.Core.SourceGenerators.csproj"
-                      SetTargetFramework="TargetFramework=netstandard2.0"
-                      OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+                      OutputItemType="None" ReferenceOutputAssembly="true" />
+                      
+    <Analyzer Include="$(RepositoryDirectory)Common\CommunityToolkit.Labs.Core.SourceGenerators\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Labs.Core.SourceGenerators.dll" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes unoplatform/uno#51
- Overrides the `Platform` variable with a valid value for the source generators project to allow building again.
- Adds validation for the override.
- Reuses the existing `PlatformTarget` value from the macOS head to define the actual platform.
- Both iOS and MacOS have been tested and build under Debug and Release mode