### PR TITLE
Fixed duplicate TargetFramework error in Visual Studio

### DIFF
--- a/Common/Labs.MultiTarget.props
+++ b/Common/Labs.MultiTarget.props
@@ -7,7 +7,7 @@
     <!--
       TargetFramework for WasmLibTargetFramework, WpfLibTargetFramework, and LinuxLibTargetFramework all use the same value.
       
-      This can't be removed during the evaluation phase without breaking things, so we emit them entirely
+      This can't be removed during the evaluation phase without breaking things, so we omit them entirely
       and use the value directly.
     -->
     <TargetFrameworks>


### PR DESCRIPTION
This PR patches an issue introduced in #50 where building in Visual Studio (instead of using msbuild from the CLI) would result in an error during package restore caused by duplicated target frameworks.