### PR TITLE
Avoid unnecessary rebuilds of the macOS head

### DIFF
--- a/Platforms/CommunityToolkit.Labs.macOS/CommunityToolkit.Labs.macOS.csproj
+++ b/Platforms/CommunityToolkit.Labs.macOS/CommunityToolkit.Labs.macOS.csproj
@@ -105,7 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\Fonts\uno-fluentui-assets.ttf">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </BundleResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />


### PR DESCRIPTION
Avoid unnecessary rebuilds of the macOS head due to a misconfigured file property.

Setting `CopyToOutputDirectory` to `Always` on any file in a project will cause the project to rebuild even if nothing has changed.
Setting the appropriate value here will improve incremental build performance.

_Note. This behavior changes for CPS projects after VS17.2, but that won't improve things for this project. More details are available if you want them._