### PR TITLE
require PowerShell Core version

### DIFF
--- a/DiscoverSamples.ps1
+++ b/DiscoverSamples.ps1
@@ -26,12 +26,12 @@ function CreateVsCodeLaunchConfigJson {
       `"/p:UnoRemoteControlPort=443`",
       `"--project=`$`{workspaceFolder`}/labs/$projectName/samples/$projectName.Wasm/$projectName.Wasm.csproj`",
       `"-p:TargetFrameworks=netstandard2.0`",
-      `"-p:TargetFramework=net5.0`",
+      `"-p:TargetFramework=net5.0`"
     ],
     `"presentation`": {
-      `"group`": `"2`",
+      `"group`": `"2`"
     },
-    `"cwd`": `"`$`{workspaceFolder`}/labs/$projectName/samples/$projectName.Wasm`",
+    `"cwd`": `"`$`{workspaceFolder`}/labs/$projectName/samples/$projectName.Wasm`"
   }";
 }
 

--- a/GenerateAllSolution.ps1
+++ b/GenerateAllSolution.ps1
@@ -1,5 +1,3 @@
-#Requires -PSEdition Core
-
 Param (
     [Parameter(HelpMessage = "The WinUI version to use when building an Uno head.", ParameterSetName = "UseUnoWinUI")]
     [ValidateSet('2', '3')]
@@ -33,7 +31,7 @@ function CreateProjectConfiguration {
 	param (
 		[string]$projectGuid
 	)
-    
+
 	# Solution files are VERY picky about the unicode characters used as newlines and tabs.
 	# These characters act strange when paired next to characters found in ASCII, so we append
 	# as separate strings.
@@ -164,14 +162,14 @@ function AddProjectsToSolution {
 
 	$projectPath = Resolve-Path -Relative -Path $projectPath;
 	$projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectPath);
-    
+
 	$sampleFolderGuid = GetFolderGuid $solutionTemplate $solutionFolder;
 
 	Write-Host "Adding $projectName to solution folder $solutionFolder";
 
 	$definition = CreateProjectDefinition $projectTypeGuid $projectGuid $projectName $projectPath;
-    
-	$templateContents = $templateContents -replace [regex]::escape($templatedProjectDefinitionsMarker), ($templatedProjectDefinitionsMarker + $definition); 
+
+	$templateContents = $templateContents -replace [regex]::escape($templatedProjectDefinitionsMarker), ($templatedProjectDefinitionsMarker + $definition);
 
 	if (-not $omitConfiguration) {
 		$configuration = CreateProjectConfiguration $projectGuid;
@@ -190,12 +188,12 @@ Write-Output "Loaded solution template from $solutionTemplatePath";
 
 # Add sample projects
 foreach ($sampleProjectPath in Get-ChildItem -Recurse -Path 'labs/*/samples/*.Sample/*.Sample.csproj') {
-	$solutionTemplate = AddProjectsToSolution $solutionTemplate $sampleProjectPath $sampleProjectTypeGuid "Samples" 
+	$solutionTemplate = AddProjectsToSolution $solutionTemplate $sampleProjectPath $sampleProjectTypeGuid "Samples"
 }
 
 # Add library projects
 foreach ($sampleProjectPath in Get-ChildItem -Recurse -Path 'labs/*/src/*.csproj') {
-	$solutionTemplate = AddProjectsToSolution $solutionTemplate $sampleProjectPath $libProjectTypeGuid "Library" 
+	$solutionTemplate = AddProjectsToSolution $solutionTemplate $sampleProjectPath $libProjectTypeGuid "Library"
 }
 
 # Add shared test projects
@@ -214,10 +212,10 @@ foreach ($sharedProjectItemsPath in Get-ChildItem -Recurse -Path 'labs/*/tests/*
 	$projectGuid = $regex.Matches.Groups[1].Value;
 
 	$sharedProjectItemsPath = Resolve-Path -Relative -Path $sharedProjectItemsPath;
-	
+
 	$sharedProjectPath = $sharedProjectItemsPath -replace "projitems", "shproj";
 	$solutionTemplate = AddProjectsToSolution $solutionTemplate $sharedProjectPath $sharedProjectTypeGuid "Experiments" $projectGuid.ToUpper() $true;
-	
+
 	$sharedProjectItemsName = [System.IO.Path]::GetFileNameWithoutExtension($sharedProjectItemsPath);
 
 	Write-Output "Linking $sharedProjectItemsName.projitems to $sharedProjectItemsName";
@@ -227,7 +225,7 @@ foreach ($sharedProjectItemsPath in Get-ChildItem -Recurse -Path 'labs/*/tests/*
 	Write-Output "Linking $sharedProjectItemsName.projitems to CommunityToolkit.Labs.UnitTests.Uwp";
 	$uwpSharedProjectDefinition = CreateSharedProjectDefinition "fd78002e-c4e6-4bf8-9ec3-c06250dfef34" $sharedProjectItemsPath "4"
 	$solutionTemplate = $solutionTemplate -replace [regex]::escape($templatedSharedTestUwpProjectSelfDefinitionsMarker), ($templatedSharedTestUwpProjectSelfDefinitionsMarker + $uwpSharedProjectDefinition);
-	
+
 	Write-Output "Linking $sharedProjectItemsName.projitems to CommunityToolkit.Labs.UnitTests.WinAppSdk";
 	$winAppSdkSharedProjectDefinition = CreateSharedProjectDefinition "53892f07-fe54-4e36-81d8-105427d097e5" $sharedProjectItemsPath "5"
 	$solutionTemplate = $solutionTemplate -replace [regex]::escape($templatedSharedTestWinAppSdkProjectSelfDefinitionsMarker), ($templatedSharedTestWinAppSdkProjectSelfDefinitionsMarker + $winAppSdkSharedProjectDefinition);


### PR DESCRIPTION
Running `GenerateAllSolution.ps1` in the "old" Windows PowerShell, there are errors reported due to changes in supported JSON formatting rules.

![image](https://user-images.githubusercontent.com/189547/167626568-334412d1-a6e5-44c1-9032-d647f32e8100.png)

This change adds a check to ensure the script only runs with PowerShell CORE which does not have a problem with how the JSON is formatted.

Adding this so that no one runs the script by double-clicking it but not seeing the error when the window closes automatically.


I assume this will be okay when run on all server environments.


