### PR TITLE
Refactor building ProjectTemplate in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,6 @@ jobs:
         working-directory: ./common/Scripts/
         run: ./UseTargetFrameworks.ps1 all
 
-      # Build and use template for creating new experiments
-      - name: Build ProjectTemplate
-        working-directory: ./template/lab
-        run: msbuild.exe ProjectTemplate.sln /restore -p:Configuration=Debug
-
       - name: Generate solution
         run: ./GenerateAllSolution.ps1
 
@@ -122,11 +117,6 @@ jobs:
       - name: Enable all TargetFrameworks
         working-directory: ./common/Scripts/
         run: ./UseTargetFrameworks.ps1 all
-
-      # Build and use template for creating new experiments
-      - name: Build ProjectTemplate
-        working-directory: ./template/lab
-        run: msbuild.exe ProjectTemplate.sln /restore -p:Configuration=Debug
 
       - name: Generate solution
         run: ./GenerateAllSolution.ps1
@@ -214,6 +204,12 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.3
 
+      # Build and use template for creating new experiments
+      - name: Build ProjectTemplate
+        working-directory: ./template/lab
+        run: msbuild.exe ProjectTemplate.sln /restore -p:Configuration=Debug
+
+      # Create a new experiment from the template and test using that
       - name: Install template
         working-directory: ./template/lab
         run: dotnet new --install ./


### PR DESCRIPTION
As the CI build for a PR is already slow, this moves the testing (building) of the Project Template out of the slowest jobs and into the job explicitly relating to experiments. - It should have been there originally. There's no real benefit to doing this twice (for WinUI2 & 3) as we currently do.

Doing this should save approx 8.5 minutes on the longest jobs in the CI/PR build.