### PR TITLE
Fixed markdown files being included from bin and obj folders

### DIFF
--- a/common/Labs.Head.props
+++ b/common/Labs.Head.props
@@ -31,7 +31,7 @@
     <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.cs" Exclude="$(RepositoryDirectory)labs\**\samples\*.Sample\obj\**\*.cs;$(RepositoryDirectory)labs\**\samples\*.Sample\bin\**\*.cs" Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension).dat" />
     
     <!-- Include markdown files from al lsamples so the head can access them in the source generator -->
-    <AdditionalFiles Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.md"/>
+    <AdditionalFiles Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.md"  Exclude="$(RepositoryDirectory)labs\**\samples\*.Sample\obj\**\*.md;$(RepositoryDirectory)labs\**\samples\*.Sample\bin\**\*.md"/>
   </ItemGroup>
   <ItemGroup Condition="$(MSBuildProjectName.Contains('ProjectTemplate'))">
     <!-- These are also included in Labs.Samples.props, but added here to workaround https://github.com/unoplatform/uno/issues/2502 -->


### PR DESCRIPTION
This fixes a bad merge that caused markdown files to be included from bin and object folders, resulting in invalid samples appearing in the app.

![image](https://user-images.githubusercontent.com/9384894/167695152-36e934fa-d9e4-48d6-a9e0-926b3735db80.png)
