### PR TITLE
Add a WASM on Linux CI Build Job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,3 +239,28 @@ jobs:
           name: Test results
           path: './TestResults/*.trx'
           reporter: dotnet-trx
+
+  wasm-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install .NET 6 SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.201'
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Generate solution
+        shell: pwsh
+        run: ./GenerateAllSolution.ps1
+
+      # Issue with Comment Links currently, see: https://github.com/mrlacey/CommentLinks/issues/38
+      # See launch.json configuration file for analogous command we're emulating here to build LINK: ../../.vscode/launch.json:CommunityToolkit.Labs.Wasm.csproj
+      - name: dotnet build
+        working-directory: ./platforms/CommunityToolkit.Labs.Wasm/
+        run: dotnet build /r /bl /p:UnoSourceGeneratorUseGenerationHost=true /p:UnoSourceGeneratorUseGenerationController=false -p:TargetFrameworks=netstandard2.0 -p:TargetFramework=net5.0
+  
+      # TODO: Do we want to run tests here? Can we do that on linux easily?


### PR DESCRIPTION
This runs the same command as launch.json for Codespaces in VS Code to build all samples. This also runs the job on linux compared to our other jobs that run on Windows.