### PR TITLE
Fixed CanvasLayout markdown being picked up by template

### DIFF
--- a/common/Labs.Head.props
+++ b/common/Labs.Head.props
@@ -24,11 +24,11 @@
 
   <ItemGroup Condition="$(MSBuildProjectName.Contains('ProjectTemplate')) == 'false'">
     <!-- These are also included in Labs.Samples.props, but added here to workaround https://github.com/unoplatform/uno/issues/2502 -->
-    <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.md" Exclude="$(RepositoryDirectory)labs\**\samples\*.Sample\obj\**\*.md;$(RepositoryDirectory)labs\**\samples\*.Sample\bin\**\*.md;$(RepositoryDirectory)\**\SourceAssets\**\*.md"  Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
-    <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.xaml" Exclude="$(RepositoryDirectory)labs\**\samples\*.Sample\obj\**\*.xaml;$(RepositoryDirectory)labs\**\samples\*.Sample\bin\**\*.xaml;$(RepositoryDirectory)\**\SourceAssets\**\*.xaml"  Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
+    <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.md" Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.md;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.md;$(RepositoryDirectory)\**\SourceAssets\**\*.md"  Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
+    <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.xaml" Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.xaml;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.xaml;$(RepositoryDirectory)\**\SourceAssets\**\*.xaml"  Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
 
     <!-- Link/.dat is a workaround for https://github.com/unoplatform/uno/issues/8649 -->
-    <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.cs" Exclude="$(RepositoryDirectory)labs\**\samples\*.Sample\obj\**\*.cs;$(RepositoryDirectory)labs\**\samples\*.Sample\bin\**\*.cs" Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension).dat" />
+    <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.cs" Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.cs;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.cs" Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension).dat" />
     
     <!-- Include markdown files from all samples so the head can access them in the source generator -->
     <AdditionalFiles Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.md"  Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.md;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.md"/>


### PR DESCRIPTION
This PR fixes an issue where tabs for CanvasLayout were showing when running the ProjectTemplate solution.

closes #116