### PR TITLE
Fix rebuild failing in individual experiment solutions

### DIFF
--- a/common/Labs.Head.props
+++ b/common/Labs.Head.props
@@ -31,8 +31,9 @@
     <Content Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.cs" Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.cs;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.cs" Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension).dat" />
     
     <!-- Include markdown files from all samples so the head can access them in the source generator -->
-    <AdditionalFiles Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.md"  Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.md;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.md"/>
+    <AdditionalFiles Include="$(RepositoryDirectory)labs\**\samples\*.Sample\**\*.md"  Exclude="$(RepositoryDirectory)**\**\samples\**\obj\**\*.md;$(RepositoryDirectory)**\**\samples\**\bin\**\*.md"/>
   </ItemGroup>
+
   <ItemGroup Condition="$(MSBuildProjectName.Contains('ProjectTemplate')) == 'true'">
     <!-- These are also included in Labs.Samples.props, but added here to workaround https://github.com/unoplatform/uno/issues/2502 -->
     <Content Include="$(RepositoryDirectory)template\**\samples\*.Sample\**\*.md" Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.md;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.md;$(RepositoryDirectory)\**\SourceAssets\**\*.md"  Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
@@ -44,6 +45,7 @@
     <!-- Include markdown files from al lsamples so the head can access them in the source generator -->
     <AdditionalFiles Include="$(RepositoryDirectory)template\**\samples\*.Sample\**\*.md" Exclude="$(RepositoryDirectory)**\**\samples\*.Sample\obj\**\*.md;$(RepositoryDirectory)**\**\samples\*.Sample\bin\**\*.md"/>  
   </ItemGroup>
+  
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>


### PR DESCRIPTION
This PR fixes .md files in a head project's bin/obj folder being included for compilation, causing individual experiments to succeed on the first build but fail on a rebuild.

Closes #118 