### PR TITLE
🚧Explicitly set LangVersion as 10.0

### DIFF
--- a/Windows.Toolkit.Common.props
+++ b/Windows.Toolkit.Common.props
@@ -17,11 +17,11 @@
     <Features>Strict</Features>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>Latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>


### PR DESCRIPTION
And only set in one place
Also removed repeated setting of `Nullable` and `WarningsAsErrors` properties

Fixes CommunityToolkit/Tooling-Windows-Submodule#64

Hopefully this is as trivial as it looks