### PR TITLE
Add rescap to template manifest for future Input Injection work

### DIFF
--- a/labs/SizerBase/tests/SizerBase.UnitTests.Uwp/Package.appxmanifest
+++ b/labs/SizerBase/tests/SizerBase.UnitTests.Uwp/Package.appxmanifest
@@ -1,9 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp rescap">
 
   <Identity Name="56364EFD-86F0-4C49-9F65-B7CCA5FB6298"
             Publisher="CN=CommunityToolkit"
@@ -41,5 +42,6 @@
   <Capabilities>
     <Capability Name="internetClientServer" />
     <Capability Name="privateNetworkClientServer" />
+    <rescap:Capability Name="inputInjectionBrokered" />
   </Capabilities>
 </Package>

--- a/labs/SizerBase/tests/SizerBase.UnitTests.WinAppSdk/Package.appxmanifest
+++ b/labs/SizerBase/tests/SizerBase.UnitTests.WinAppSdk/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -43,5 +43,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <rescap:Capability Name="inputInjectionBrokered" />
   </Capabilities>
 </Package>

--- a/tests/CommunityToolkit.Labs.UnitTests.Uwp/Package.appxmanifest
+++ b/tests/CommunityToolkit.Labs.UnitTests.Uwp/Package.appxmanifest
@@ -1,9 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp rescap">
 
   <Identity Name="7af355f7-0c20-4a39-9b71-8cf779ccfa82"
             Publisher="CN=CommunityToolkit"
@@ -42,5 +43,6 @@
   <Capabilities>
     <Capability Name="internetClientServer" />
     <Capability Name="privateNetworkClientServer" />
+    <rescap:Capability Name="inputInjectionBrokered" />
   </Capabilities>
 </Package>

--- a/tests/CommunityToolkit.Labs.UnitTests.WinAppSdk/Package.appxmanifest
+++ b/tests/CommunityToolkit.Labs.UnitTests.WinAppSdk/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -44,5 +44,6 @@
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <rescap:Capability Name="inputInjectionBrokered" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
Want to see if the UWP test passes in the CI (WinAppSDK won't work locally as test point is out of place, so expect that to fail.)

Based off of #156, so don't look at changes here until that's merged to main.