### PR TITLE
Fix #164 - Move AdditionalFiles to props file out of project template

### DIFF
--- a/common/Labs.Sample.props
+++ b/common/Labs.Sample.props
@@ -17,6 +17,9 @@
 
   <ItemGroup>
     <Compile Include="$(RepositoryDirectory)common\GlobalUsings_Samples.cs" />
+
+    <!-- Needed for Source Generators to find Markdown files -->
+    <AdditionalFiles Include="**\*.md" Exclude="bin\**\*.md;obj\**\*.md" />
   </ItemGroup>
 
 </Project>

--- a/labs/CanvasLayout/samples/CanvasLayout.Sample/CanvasLayout.Sample.csproj
+++ b/labs/CanvasLayout/samples/CanvasLayout.Sample/CanvasLayout.Sample.csproj
@@ -38,9 +38,6 @@
     <UpToDateCheckInput Remove="SamplePageOptions.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="*.md" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.CanvasLayout.csproj"/>
   </ItemGroup>
 </Project>

--- a/labs/SizerBase/samples/SizerBase.Sample/SizerBase.Sample.csproj
+++ b/labs/SizerBase/samples/SizerBase.Sample/SizerBase.Sample.csproj
@@ -20,9 +20,6 @@
     <UpToDateCheckInput Remove="obj\bin\**" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="*.md" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.SizerBase.csproj" />
   </ItemGroup>
 </Project>

--- a/template/lab/samples/ProjectTemplate.Sample/ProjectTemplate.Sample.csproj
+++ b/template/lab/samples/ProjectTemplate.Sample/ProjectTemplate.Sample.csproj
@@ -24,9 +24,6 @@
     <None Remove="ProjectTemplateFirstSamplePage.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="*.md" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Remove="ProjectTemplate.md" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Did notice an issue running `CanvasLayout` experiment under WinAppSDK, but that's happening on main as well. Will need to open an issue and probably regenerate off of current template as it's our original hand-molded solution.

Anyway, this resolves #164 and just moves looking for the `AdditionalFiles` for Markdown files into the `Labs.Samples.props` file.