### PR TITLE
Define `LangVersion` as "10.0" and only once

### DIFF
--- a/Windows.Toolkit.Common.props
+++ b/Windows.Toolkit.Common.props
@@ -17,7 +17,7 @@
     <Features>Strict</Features>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>

--- a/common/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod.Tests/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod.Tests.csproj
+++ b/common/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod.Tests/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/common/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod.csproj
+++ b/common/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod/CommunityToolkit.Labs.Core.SourceGenerators.LabsUITestMethod.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/common/CommunityToolkit.Labs.Core.SourceGenerators.Tests/CommunityToolkit.Labs.Core.SourceGenerators.Tests/CommunityToolkit.Labs.Core.SourceGenerators.Tests.csproj
+++ b/common/CommunityToolkit.Labs.Core.SourceGenerators.Tests/CommunityToolkit.Labs.Core.SourceGenerators.Tests/CommunityToolkit.Labs.Core.SourceGenerators.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/common/CommunityToolkit.Labs.Core.SourceGenerators.XamlNamedPropertyRelay/CommunityToolkit.Labs.Core.SourceGenerators.XamlNamedPropertyRelay.csproj
+++ b/common/CommunityToolkit.Labs.Core.SourceGenerators.XamlNamedPropertyRelay/CommunityToolkit.Labs.Core.SourceGenerators.XamlNamedPropertyRelay.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/common/CommunityToolkit.Labs.Core.SourceGenerators/CommunityToolkit.Labs.Core.SourceGenerators.csproj
+++ b/common/CommunityToolkit.Labs.Core.SourceGenerators/CommunityToolkit.Labs.Core.SourceGenerators.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes CommunityToolkit/Tooling-Windows-Submodule#64
Also, removes some properties that were unnecessarily set more than once.

Note. This will not currently pass due to a bug in the version of Uno.UI (4.2.6) that is currently being used. Updating this to the latest stable version breaks other things.

Opening this now (as a draft) so that it's ready when related issues (#174) have been addressed.


This replaces CommunityToolkit/Labs-Windows#150 as that branch had become messy while exploring the cause of related issues.