### PR TITLE
Additional unit tests for option pane generator

### DIFF
--- a/common/CommunityToolkit.Labs.Core.SourceGenerators.Tests/CommunityToolkit.Labs.Core.SourceGenerators.Tests/ToolkitSampleMetadataTests.cs
+++ b/common/CommunityToolkit.Labs.Core.SourceGenerators.Tests/CommunityToolkit.Labs.Core.SourceGenerators.Tests/ToolkitSampleMetadataTests.cs
@@ -46,6 +46,7 @@ public partial class ToolkitSampleMetadataTests
         VerifyGeneratedDiagnostics<ToolkitSampleOptionGenerator>(source, string.Empty);
     }
 
+    // https://github.com/CommunityToolkit/Labs-Windows/issues/175
     [TestMethod]
     public void PaneOption_GeneratesProperty_DuplicatePropNamesAcrossSampleClasses()
     {


### PR DESCRIPTION
Closes #175

This PR
- Adds a guard to make sure tests run without compilation errors
- Adds a test to ensure sample pane properties fully generate
- Adds a test to ensure sample pane properties fully generate when the same name is used in multiple classes, covering a previous issue found in #167