### PR TITLE
Fixes #146 - Add example comments for a Toolkit package example

### DIFF
--- a/template/lab/src/Dependencies.WinUI2.props
+++ b/template/lab/src/Dependencies.WinUI2.props
@@ -12,9 +12,9 @@
 -->
 <Project>
     <ItemGroup Condition="'$(IsUwp)' == 'True'">
-
+        <!--<PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.2"/>-->
     </ItemGroup>
     <ItemGroup Condition="'$(WinUIMajorVersion)' == '2' AND '$(IsUno)' == 'True'">
-
+        <!--<PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/>-->
     </ItemGroup>
 </Project>

--- a/template/lab/src/Dependencies.WinUI3.props
+++ b/template/lab/src/Dependencies.WinUI3.props
@@ -12,9 +12,9 @@
 -->
 <Project>
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'True'">
-
+        <!--<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2"/>-->
     </ItemGroup>
     <ItemGroup Condition="'$(WinUIMajorVersion)' == '3' AND '$(IsUno)' == 'True'">
-
+        <!--<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.100-dev.15.g12261e2626"/>-->
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #146

Note: that most likely someone will want to abstract/wrap an unsealed toolkit component to expose it under a common namespace to be used in their component's XAML. We'll want to add this to the wiki, at least until we get an 8.0 build which has everything together already for this, e.g.

```cs
#if WINAPPSDK
using ToolkitWP = CommunityToolkit.WinUI.UI.Controls.WrapPanel;
#else
using ToolkitWP = Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel;
#endif

namespace CommunityToolkit.Labs.ExperimentName;

/// <summary>
/// Provide an abstraction around the Toolkit WrapPanel for both UWP and WinUI 3 in the same namespace (until 8.0).
/// </summary>
public partial class WrapPanel: ToolkitWP
{
}
```