### PR TITLE
Shorten Identity in manifests

### DIFF
--- a/labs/CanvasLayout/samples/CanvasLayout.Uwp/Package.appxmanifest
+++ b/labs/CanvasLayout/samples/CanvasLayout.Uwp/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap mp">
 
   <Identity
-    Name="Labs.CanvasLayout.Samples.Uwp"
+    Name="Labs.CanvasLayout.Uwp"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/labs/CanvasLayout/samples/CanvasLayout.WinAppSdk/Package.appxmanifest
+++ b/labs/CanvasLayout/samples/CanvasLayout.WinAppSdk/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="Labs.CanvasLayout.Samples.WinAppSdk"
+    Name="Labs.CanvasLayout.AppSdk"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/labs/CanvasLayout/tests/CanvasLayout.Tests.WinAppSdk/Package.appxmanifest
+++ b/labs/CanvasLayout/tests/CanvasLayout.Tests.WinAppSdk/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="Labs.CanvasLayout.Tests.WinAppSdk"
+    Name="Labs.CanvasLayout.Tests.AppSdk"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/labs/SizerBase/samples/SizerBase.Uwp/Package.appxmanifest
+++ b/labs/SizerBase/samples/SizerBase.Uwp/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap mp">
 
   <Identity
-    Name="Labs.SizerBase.Samples.Uwp"
+    Name="Labs.SizerBase.Uwp"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/labs/SizerBase/samples/SizerBase.WinAppSdk/Package.appxmanifest
+++ b/labs/SizerBase/samples/SizerBase.WinAppSdk/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="Labs.SizerBase.Samples.WinAppSdk"
+    Name="Labs.SizerBase.AppSdk"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/labs/SizerBase/tests/SizerBase.Tests.WinAppSdk/Package.appxmanifest
+++ b/labs/SizerBase/tests/SizerBase.Tests.WinAppSdk/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="Labs.SizerBase.Tests.WinAppSdk"
+    Name="Labs.SizerBase.Tests.AppSdk"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/template/README.md
+++ b/template/README.md
@@ -81,3 +81,7 @@ If when adding a new page to the sample project you run into errors, try resetti
 If you are referring to a control from the system like `TextBlock`, the build system will automatically pick the system one on UWP or the WinUI 3 one in the Windows App SDK.
 
 However, if you need to refer to a component that was part of the WinUI 2 library like `NavigationView` or `ItemsRepeater`, then preface your C# code type with `MUXC.` to clarify you are referring to the WinUI 2 or WinUI 3 versions of the components. In XAML this is done automatically as the namespace is the same (and it is effectively ignored in the WinUI 3 case).
+
+#### DEP0600 error (WinAppSDK)
+
+Your experiment name is probably too long (max 32 characters), use a shorter more concise name when generating your template. See [this issue here](https://github.com/microsoft/microsoft-ui-xaml/issues/7059).

--- a/template/lab/samples/ProjectTemplate.Uwp/Package.appxmanifest
+++ b/template/lab/samples/ProjectTemplate.Uwp/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap mp">
 
   <Identity
-    Name="Labs.ProjectTemplate.Samples.Uwp"
+    Name="Labs.ProjectTemplate.Uwp"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/template/lab/samples/ProjectTemplate.WinAppSdk/Package.appxmanifest
+++ b/template/lab/samples/ProjectTemplate.WinAppSdk/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="Labs.ProjectTemplate.Samples.WinAppSdk"
+    Name="Labs.ProjectTemplate.AppSdk"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 

--- a/template/lab/tests/ProjectTemplate.Tests.WinAppSdk/Package.appxmanifest
+++ b/template/lab/tests/ProjectTemplate.Tests.WinAppSdk/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="Labs.ProjectTemplate.Tests.WinAppSdk"
+    Name="Labs.ProjectTemplate.Tests.AppSdk"
     Publisher="CN=CommunityToolkit"
     Version="1.0.0.0" />
 


### PR DESCRIPTION
Work-around for https://github.com/microsoft/microsoft-ui-xaml/issues/7059

Gives us a maximum of 32 characters for an experiment name. 
Added note in template readme about it too.