### PR TITLE
[Gallery] Adding right-to-left toggle

### DIFF
--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml
@@ -7,6 +7,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       xmlns:renderer="using:CommunityToolkit.Labs.Shared.Renderers"
+      xmlns:wasm="http://uno.ui/wasm"
       xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       Loaded="ToolkitSampleRenderer_Loaded"
       mc:Ignorable="d">
@@ -104,6 +105,7 @@
                                 DefaultLabelPosition="Collapsed"
                                 OverflowButtonVisibility="Collapsed">
 
+                        <!--  TO DO: This doesn't seem to work in Uno?  -->
                         <AppBarButton x:Name="ThemeBtn"
                                       Click="ThemeBtn_OnClick"
                                       Label="Toggle theme"
@@ -113,13 +115,15 @@
                             </AppBarButton.Icon>
                         </AppBarButton>
 
-                        <!--  TO DO: Implement FlowDirection  -->
-                        <!--<AppBarButton Label="Toggle right-to-left"
+                        <AppBarButton x:Name="FlowDirectionBtn"
+                                      Click="FlowDirectionBtn_OnClick"
+                                      Label="Toggle flow direction"
                                       ToolTipService.ToolTip="Toggle right-to-left">
+
                             <AppBarButton.Icon>
                                 <FontIcon Glyph="&#xE1A0;" />
                             </AppBarButton.Icon>
-                        </AppBarButton>-->
+                        </AppBarButton>
                         <AppBarSeparator x:Name="SeperatorLine" />
                         <AppBarButton x:Name="CodeBtn"
                                       Click="CodeBtn_OnClick"

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -277,6 +277,20 @@ public sealed partial class ToolkitSampleRenderer : Page
         }
     }
 
+    private void FlowDirectionBtn_OnClick(object sender, RoutedEventArgs e)
+    {
+#if !HAS_UNO
+        if (PageControl.FlowDirection == FlowDirection.LeftToRight)
+        {
+            PageControl.FlowDirection = FlowDirection.RightToLeft;
+        }
+        else
+        {
+            PageControl.FlowDirection = FlowDirection.LeftToRight;
+        }
+#endif
+    }
+
     private void CodeBtn_OnClick(object sender, RoutedEventArgs e)
     {
         SourcecodeExpander.IsExpanded = !SourcecodeExpander.IsExpanded;


### PR DESCRIPTION
This PR adds a right-to-left toggle so developers can test how their controls.

![rtl](https://user-images.githubusercontent.com/9866362/184327890-f4a1c3ef-a345-4b43-9422-bdc1554d007b.gif)


@michael-hawker @Arlodotexe 
FlowDirection does not seem to be supported in Uno - however, when I try to hide the button using:

  <!--  wasm:Visibility="Collapsed" -->
  
  I get an error when trying to run the UWP head ("Visibility not found on AppBarButton"). Any thoughts on why that is?