### PR TITLE
[SettingsControls] Fix for overriding not working

### DIFF
--- a/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
+++ b/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
@@ -18,7 +18,7 @@
     <Description>
       This package contains the SettingsCard and SettingsExpander controls.
     </Description>
-    <Version>0.0.5</Version>
+    <Version>0.0.6</Version>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
@@ -121,17 +121,17 @@
             <Setter Property="BorderBrush" Value="{ThemeResource SettingsCardBorderBrush}" />
             <Setter Property="BorderThickness" Value="{ThemeResource SettingsCardBorderThickness}" />
             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-            <Setter Property="MinHeight" Value="{StaticResource SettingsCardMinHeight}" />
+            <Setter Property="MinHeight" Value="{ThemeResource SettingsCardMinHeight}" />
             <!--<Setter Property="win:AutomationProperties.AutomationControlType" Value="Group" />-->
             <!--<Setter Property="win:AutomationProperties.Name" Value="{TemplateBinding Header}" />-->
-            <Setter Property="MaxWidth" Value="{StaticResource SettingsCardMaxWidth}" />
-            <Setter Property="MinWidth" Value="{StaticResource SettingsCardMinWidth}" />
+            <Setter Property="MaxWidth" Value="{ThemeResource SettingsCardMaxWidth}" />
+            <Setter Property="MinWidth" Value="{ThemeResource SettingsCardMinWidth}" />
             <Setter Property="IsTabStop" Value="False" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="HorizontalContentAlignment" Value="Right" />
             <Setter Property="VerticalAlignment" Value="Center" />
             <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
-            <Setter Property="Padding" Value="{StaticResource SettingsCardPadding}" />
+            <Setter Property="Padding" Value="{ThemeResource SettingsCardPadding}" />
             <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
             <Setter Property="FontWeight" Value="Normal" />
             <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
@@ -148,19 +148,19 @@
                         <Style BasedOn="{StaticResource DefaultSliderStyle}"
                                TargetType="Slider">
                             <Style.Setters>
-                                <Setter Property="MinWidth" Value="{StaticResource SettingsCardContentMinWidth}" />
+                                <Setter Property="MinWidth" Value="{ThemeResource SettingsCardContentMinWidth}" />
                             </Style.Setters>
                         </Style>
                         <Style BasedOn="{StaticResource DefaultComboBoxStyle}"
                                TargetType="ComboBox">
                             <Style.Setters>
-                                <Setter Property="MinWidth" Value="{StaticResource SettingsCardContentMinWidth}" />
+                                <Setter Property="MinWidth" Value="{ThemeResource SettingsCardContentMinWidth}" />
                             </Style.Setters>
                         </Style>
                         <Style BasedOn="{StaticResource DefaultTextBoxStyle}"
                                TargetType="TextBox">
                             <Style.Setters>
-                                <Setter Property="MinWidth" Value="{StaticResource SettingsCardContentMinWidth}" />
+                                <Setter Property="MinWidth" Value="{ThemeResource SettingsCardContentMinWidth}" />
                             </Style.Setters>
                         </Style>
 
@@ -321,7 +321,7 @@
                                             <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="1" />
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="Left" />
-                                            <Setter Target="PART_ContentPresenter.Margin" Value="{StaticResource SettingsCardVerticalHeaderContentSpacing}" />
+                                            <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
                                         </VisualState.Setters>
                                     </VisualState>
                                     <VisualState x:Name="Vertical">
@@ -334,7 +334,7 @@
                                             <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="1" />
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource TemplatedParent}}" />
-                                            <Setter Target="PART_ContentPresenter.Margin" Value="{StaticResource SettingsCardVerticalHeaderContentSpacing}" />
+                                            <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
                                         </VisualState.Setters>
                                     </VisualState>
                                 </VisualStateGroup>
@@ -342,9 +342,9 @@
 
                             <ContentPresenter x:Name="PART_HeaderIconPresenter"
                                               Grid.RowSpan="1"
-                                              MaxWidth="{StaticResource SettingsCardIconMaxSize}"
-                                              MaxHeight="{StaticResource SettingsCardIconMaxSize}"
-                                              Margin="{StaticResource SettingsCardHeaderIconMargin}"
+                                              MaxWidth="{ThemeResource SettingsCardIconMaxSize}"
+                                              MaxHeight="{ThemeResource SettingsCardIconMaxSize}"
+                                              Margin="{ThemeResource SettingsCardHeaderIconMargin}"
                                               win:HighContrastAdjustment="None"
                                               Content="{TemplateBinding HeaderIcon}" />
 
@@ -361,7 +361,7 @@
 
                                 <ContentPresenter x:Name="PART_DescriptionPresenter"
                                                   Content="{TemplateBinding Description}"
-                                                  FontSize="{StaticResource SettingsCardDescriptionFontSize}"
+                                                  FontSize="{ThemeResource SettingsCardDescriptionFontSize}"
                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                   TextWrapping="Wrap">
                                     <ContentPresenter.Resources>
@@ -374,7 +374,7 @@
                                         <Style BasedOn="{StaticResource DefaultHyperlinkButtonStyle}"
                                                TargetType="HyperlinkButton">
                                             <Style.Setters>
-                                                <Setter Property="FontSize" Value="{StaticResource SettingsCardDescriptionFontSize}" />
+                                                <Setter Property="FontSize" Value="{ThemeResource SettingsCardDescriptionFontSize}" />
                                                 <Setter Property="Padding" Value="0,0,0,-1" />
                                             </Style.Setters>
                                         </Style>
@@ -390,21 +390,17 @@
 
                             <ContentPresenter x:Name="PART_ContentPresenter"
                                               Grid.Column="2"
-                                              MinWidth="{StaticResource SettingsCardContentMinWidth}"
+                                              MinWidth="{ThemeResource SettingsCardContentMinWidth}"
                                               HorizontalAlignment="Right"
                                               VerticalAlignment="Center"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              Content="{TemplateBinding Content}">
-                                <!--
-                                    TO DO: Set MinWidth of 116px on the hosted Content: SettingsCardContentMinWidth
-                                -->
-                            </ContentPresenter>
+                                              Content="{TemplateBinding Content}"/>
 
                             <ContentControl x:Name="PART_ActionIconPresenter"
                                             Grid.RowSpan="2"
                                             Grid.Column="3"
-                                            Width="{StaticResource SettingsCardActionButtonWidth}"
-                                            Height="{StaticResource SettingsCardActionButtonHeight}"
+                                            Width="{ThemeResource SettingsCardActionButtonWidth}"
+                                            Height="{ThemeResource SettingsCardActionButtonHeight}"
                                             Margin="4,0,-8,0"
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
@@ -164,7 +164,7 @@
                             </Style.Setters>
                         </Style>
 
-                        <!--  NumberBox is not being recognized?  -->
+                        <!--  NumberBox is not recognized?  -->
                         <!--<Style
                             TargetType="NumberBox">
                             <Style.Setters>
@@ -394,7 +394,7 @@
                                               HorizontalAlignment="Right"
                                               VerticalAlignment="Center"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              Content="{TemplateBinding Content}"/>
+                                              Content="{TemplateBinding Content}" />
 
                             <ContentControl x:Name="PART_ActionIconPresenter"
                                             Grid.RowSpan="2"

--- a/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
+++ b/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
@@ -21,9 +21,9 @@
            BasedOn="{StaticResource DefaultSettingsCardStyle}"
            TargetType="labs:SettingsCard">
         <Style.Setters>
-            <Setter Property="BorderThickness" Value="{StaticResource SettingsExpanderItemBorderThickness}" />
+            <Setter Property="BorderThickness" Value="{ThemeResource SettingsExpanderItemBorderThickness}" />
             <Setter Property="MinHeight" Value="52" />
-            <Setter Property="Padding" Value="{StaticResource SettingsExpanderItemPadding}" />
+            <Setter Property="Padding" Value="{ThemeResource SettingsExpanderItemPadding}" />
             <Setter Property="CornerRadius" Value="0" />
         </Style.Setters>
     </Style>
@@ -32,7 +32,7 @@
            BasedOn="{StaticResource DefaultSettingsExpanderItemStyle}"
            TargetType="labs:SettingsCard">
         <Style.Setters>
-            <Setter Property="Padding" Value="{StaticResource ClickableSettingsExpanderItemPadding}" />
+            <Setter Property="Padding" Value="{ThemeResource ClickableSettingsExpanderItemPadding}" />
         </Style.Setters>
     </Style>
 
@@ -52,17 +52,17 @@
             <Setter Property="BorderBrush" Value="{ThemeResource SettingsCardBorderBrush}" />
             <Setter Property="BorderThickness" Value="{ThemeResource SettingsCardBorderThickness}" />
             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-            <Setter Property="MinHeight" Value="{StaticResource SettingsCardMinHeight}" />
+            <Setter Property="MinHeight" Value="{ThemeResource SettingsCardMinHeight}" />
             <!--<Setter Property="win:AutomationProperties.AutomationControlType" Value="Group" />-->
             <!--<Setter Property="win:AutomationProperties.Name" Value="{TemplateBinding Header}" />-->
-            <Setter Property="MaxWidth" Value="{StaticResource SettingsCardMaxWidth}" />
-            <Setter Property="MinWidth" Value="{StaticResource SettingsCardMinWidth}" />
+            <Setter Property="MaxWidth" Value="{ThemeResource SettingsCardMaxWidth}" />
+            <Setter Property="MinWidth" Value="{ThemeResource SettingsCardMinWidth}" />
             <Setter Property="IsTabStop" Value="False" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
             <Setter Property="VerticalAlignment" Value="Center" />
             <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
-            <Setter Property="Padding" Value="{StaticResource SettingsExpanderHeaderPadding}" />
+            <Setter Property="Padding" Value="{ThemeResource SettingsExpanderHeaderPadding}" />
             <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
             <Setter Property="FontWeight" Value="Normal" />
             <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />


### PR DESCRIPTION
For a demo, I wanted to override the MaxIconWidth - which wasn't working. Problem was using the StaticResource reference.

I have replaced all overrides to ThemeResources so they should now work as expected.