### PR TITLE
[SettingsControls] Final design tweaks

### DIFF
--- a/labs/SettingsControls/samples/SettingsControls.Samples/ClickableSettingsCardSample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/ClickableSettingsCardSample.xaml
@@ -27,8 +27,7 @@
                 <FontIcon Glyph="&#xE12B;" />
             </labs:SettingsCard.HeaderIcon>
             <labs:SettingsCard.ActionIcon>
-                <FontIcon FontSize="12"
-                          Glyph="&#xE8A7;" />
+                <FontIcon Glyph="&#xE8A7;" />
             </labs:SettingsCard.ActionIcon>
         </labs:SettingsCard>
     </StackPanel>

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsPageExample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsPageExample.xaml
@@ -7,7 +7,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
     <ScrollViewer>
-        <StackPanel Spacing="4">
+        <StackPanel Spacing="4" HorizontalAlignment="Stretch" MaxWidth="1000">
             <!--  TODO: @Niels - I just copied everything here, not sure if any values need adjusting. We should probably use this as a place to have more bespoke examples of each type of content like Slider, ComboBox, TextBox, etc...  -->
             <TextBlock Margin="1,0,0,4"
                        Style="{StaticResource BodyStrongTextBlockStyle}"

--- a/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
+++ b/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
+﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
   <!-- Labs Constants -->
   <Import Project="$(RepositoryDirectory)common\Labs.TargetFrameworks.props" />
   <Import Project="$(RepositoryDirectory)common\Labs.ProjectIdentifiers.props" />
@@ -18,7 +18,7 @@
     <Description>
       This package contains the SettingsCard and SettingsExpander controls.
     </Description>
-    <Version>0.0.7</Version>
+    <Version>0.0.8</Version>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs
@@ -37,7 +37,7 @@ public partial class SettingsCard : ButtonBase
     /// </summary>
     public static readonly DependencyProperty ActionIconProperty = DependencyProperty.Register(
         nameof(ActionIcon),
-        typeof(object),
+        typeof(IconElement),
         typeof(SettingsCard),
         new PropertyMetadata(defaultValue: "\ue974"));
 

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -18,7 +18,7 @@ public partial class SettingsCard : ButtonBase
     private const string ActionIconPresenter = "PART_ActionIconPresenter";
     private const string HeaderPresenter = "PART_HeaderPresenter";
     private const string DescriptionPresenter = "PART_DescriptionPresenter";
-    private const string HeaderIconPresenter = "PART_HeaderIconPresenter";
+    private const string HeaderIconPresenter = "PART_HeaderIconPresenterHolder";
     /// <summary>
     /// Creates a new instance of the <see cref="SettingsCard"/> class.
     /// </summary>

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -103,7 +103,8 @@
     <x:Double x:Key="SettingsCardActionButtonWidth">32</x:Double>
     <x:Double x:Key="SettingsCardActionButtonHeight">32</x:Double>
     <x:Double x:Key="SettingsCardDescriptionFontSize">12</x:Double>
-    <x:Double x:Key="SettingsCardIconMaxSize">20</x:Double>
+    <x:Double x:Key="SettingsCardHeaderIconMaxSize">20</x:Double>
+    <x:Double x:Key="SettingsCardActionIconMaxSize">13</x:Double>
     <x:Double x:Key="SettingsCardLeftIndention">0</x:Double>
     <x:Double x:Key="SettingsCardContentMinWidth">120</x:Double>
     <Thickness x:Key="SettingsCardHeaderIconMargin">2,0,20,0</Thickness>
@@ -303,7 +304,7 @@
                                                                       To="Left" />
                                         </VisualState.StateTriggers>
                                         <VisualState.Setters>
-                                            <Setter Target="PART_HeaderIconPresenter.Visibility" Value="Collapsed" />
+                                            <Setter Target="PART_HeaderIconPresenterHolder.Visibility" Value="Collapsed" />
                                             <Setter Target="PART_DescriptionPresenter.Visibility" Value="Collapsed" />
                                             <Setter Target="PART_HeaderPresenter.Visibility" Value="Collapsed" />
                                             <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="0" />
@@ -340,13 +341,15 @@
                                 </VisualStateGroup>
                             </VisualStateManager.VisualStateGroups>
 
-                            <ContentPresenter x:Name="PART_HeaderIconPresenter"
-                                              Grid.RowSpan="1"
-                                              MaxWidth="{ThemeResource SettingsCardIconMaxSize}"
-                                              MaxHeight="{ThemeResource SettingsCardIconMaxSize}"
-                                              Margin="{ThemeResource SettingsCardHeaderIconMargin}"
-                                              win:HighContrastAdjustment="None"
-                                              Content="{TemplateBinding HeaderIcon}" />
+                            <Viewbox x:Name="PART_HeaderIconPresenterHolder"
+                                     Grid.RowSpan="1"
+                                     MaxWidth="{ThemeResource SettingsCardHeaderIconMaxSize}"
+                                     MaxHeight="{ThemeResource SettingsCardHeaderIconMaxSize}"
+                                     Margin="{ThemeResource SettingsCardHeaderIconMargin}">
+                                <ContentPresenter x:Name="PART_HeaderIconPresenter"
+                                                  win:HighContrastAdjustment="None"
+                                                  Content="{TemplateBinding HeaderIcon}" />
+                            </Viewbox>
 
                             <StackPanel Grid.Column="1"
                                         Margin="0,0,12,0"
@@ -409,15 +412,19 @@
                                             win:AutomationProperties.LocalizedControlType="button"
                                             win:AutomationProperties.Name="{TemplateBinding ActionIconToolTip}"
                                             win:HighContrastAdjustment="None"
-                                            Content="{TemplateBinding ActionIcon}"
                                             CornerRadius="{ThemeResource ControlCornerRadius}"
                                             FocusVisualMargin="-3"
                                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                            FontSize="11"
                                             IsTabStop="True"
                                             ToolTipService.ToolTip="{TemplateBinding ActionIconToolTip}"
                                             UseSystemFocusVisuals="True"
-                                            Visibility="Collapsed" />
+                                            Visibility="Collapsed">
+                                <Viewbox MaxWidth="{ThemeResource SettingsCardActionIconMaxSize}"
+                                         MaxHeight="{ThemeResource SettingsCardActionIconMaxSize}">
+                                    <ContentPresenter win:HighContrastAdjustment="None"
+                                                      Content="{TemplateBinding ActionIcon}" />
+                                </Viewbox>
+                            </ContentControl>
                         </Grid>
                     </ControlTemplate>
                 </Setter.Value>

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -144,7 +144,6 @@
                         <!--  Making sure ToggleSwitches are right-aligned by default  -->
                         <Style BasedOn="{StaticResource RightAlignedCompactToggleSwitchStyle}"
                                TargetType="ToggleSwitch" />
-
                         <!--  Overriding the MinWidth of various types of controls so they neatly align  -->
                         <Style BasedOn="{StaticResource DefaultSliderStyle}"
                                TargetType="Slider">

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -379,12 +379,14 @@
                                             <Style.Setters>
                                                 <Setter Property="FontSize" Value="{ThemeResource SettingsCardDescriptionFontSize}" />
                                                 <Setter Property="Padding" Value="0,0,0,-1" />
+                                                <Setter Property="FontWeight" Value="SemiBold" />
                                             </Style.Setters>
                                         </Style>
                                         <Style TargetType="Hyperlink">
                                             <Style.Setters>
                                                 <Setter Property="UnderlineStyle" Value="None" />
                                                 <Setter Property="TextDecorations" Value="None" />
+                                                <Setter Property="FontWeight" Value="SemiBold" />
                                             </Style.Setters>
                                         </Style>
                                     </ContentPresenter.Resources>


### PR DESCRIPTION
Final (I promise :)) design tweaks:

- SettingsPage sample alignment (headers weren't correctly aligning on resize)
- HyperLink(Buttons) in a description are now SemiBold by default, like in W11 Settings
- Icons are now wrapped in ViewBox to make sure they render properly:

(before vs. after)
![image](https://user-images.githubusercontent.com/9866362/199246966-342d12df-e063-4b56-98fd-5df830cdb857.png)


