### PR TITLE
[Gallery] Adding a link to the preview package wikipage

### DIFF
--- a/common/CommunityToolkit.Labs.Shared/App.xaml
+++ b/common/CommunityToolkit.Labs.Shared/App.xaml
@@ -7,6 +7,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <ResourceDictionary Source="/Styles/Buttons.xaml" />
+                <ResourceDictionary Source="/Styles/Colors.xaml" />
                 <ResourceDictionary Source="/Styles/ItemTemplates.xaml" />
                 <ResourceDictionary Source="/Controls/TitleBar/TitleBar.xaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/common/CommunityToolkit.Labs.Shared/CommunityToolkit.Labs.Shared.projitems
+++ b/common/CommunityToolkit.Labs.Shared/CommunityToolkit.Labs.Shared.projitems
@@ -94,6 +94,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Styles\Colors.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Styles\ItemTemplates.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitDocumentationRenderer.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitDocumentationRenderer.xaml
@@ -9,6 +9,7 @@
       xmlns:local="using:CommunityToolkit.Labs.Shared"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:metadata="using:CommunityToolkit.Labs.Core.SourceGenerators.Metadata"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       xmlns:renderer="using:CommunityToolkit.Labs.Shared.Renderers"
       xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       mc:Ignorable="d">
@@ -78,16 +79,17 @@
 
         <ScrollViewer Grid.Row="1">
             <ItemsControl x:Name="DocItemsControl"
-                          Margin="32,0,32,0"
+                          Margin="40,0,40,0"
                           ItemTemplateSelector="{StaticResource DocOrSampleTemplateSelector}"
                           ItemsSource="{x:Bind DocsAndSamples, Mode=OneWay}" />
         </ScrollViewer>
 
         <!--  Header grid  -->
         <Grid x:Name="HeaderGrid"
-              Margin="32,16,32,32"
+              Margin="40,24,40,40"
               VerticalAlignment="Top">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -110,8 +112,7 @@
 
                 <StackPanel Orientation="Horizontal"
                             Spacing="8">
-                    <Button Grid.Column="0"
-                            Style="{StaticResource AccentButtonStyle}">
+                    <Button Grid.Column="0">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon FontSize="14"
                                       Glyph="&#xE130;" />
@@ -124,8 +125,7 @@
                             </interactions:EventTriggerBehavior>
                         </interactivity:Interaction.Behaviors>
                     </Button>
-                    <Button Grid.Column="1"
-                            Style="{StaticResource AccentButtonStyle}">
+                    <Button Grid.Column="1">
                         <StackPanel Orientation="Horizontal">
                             <PathIcon Margin="-3"
                                       VerticalAlignment="Center"
@@ -156,6 +156,7 @@
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Text="Sample:" />
                     <ComboBox x:Name="SampleSelectionBox"
+                              MinWidth="160"
                               ItemsSource="{x:Bind Samples, Mode=OneWay}"
                               SelectedIndex="0"
                               SelectionChanged="SampleSelectionBox_SelectionChanged">
@@ -165,17 +166,18 @@
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
-                    <!--<Button Height="32">
-                        <FontIcon FontSize="14"
-                                  Glyph="&#xE1A0;" />
-                    </Button>
-
-                    <Button Height="32">
-                        <FontIcon FontSize="14"
-                                  Glyph="&#xE793;" />
-                    </Button>-->
                 </StackPanel>
             </Grid>
+            <muxc:InfoBar Title="Experimental"
+                          Grid.Row="3"
+                          Margin="0,16,0,0"
+                          IsClosable="False"
+                          IsOpen="True">
+                <muxc:InfoBar.ActionButton>
+                    <HyperlinkButton Content="Learn more how you can use this experiment in your app"
+                                     NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki/Preview-Packages#toolkit-labs-" />
+                </muxc:InfoBar.ActionButton>
+            </muxc:InfoBar>
         </Grid>
     </Grid>
 </Page>

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitDocumentationRenderer.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitDocumentationRenderer.xaml
@@ -174,7 +174,7 @@
                           IsClosable="False"
                           IsOpen="True">
                 <muxc:InfoBar.ActionButton>
-                    <HyperlinkButton Content="Learn more how you can use this experiment in your app"
+                    <HyperlinkButton Content="Learn how you can use this experiment in your app"
                                      NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki/Preview-Packages#toolkit-labs-" />
                 </muxc:InfoBar.ActionButton>
             </muxc:InfoBar>

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitDocumentationRenderer.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitDocumentationRenderer.xaml
@@ -175,7 +175,7 @@
                           IsOpen="True">
                 <muxc:InfoBar.ActionButton>
                     <HyperlinkButton Content="Learn how you can use this experiment in your app"
-                                     NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki/Preview-Packages#toolkit-labs-" />
+                                     NavigateUri="https://aka.ms/wct/wiki/previewpackages" />
                 </muxc:InfoBar.ActionButton>
             </muxc:InfoBar>
         </Grid>

--- a/common/CommunityToolkit.Labs.Shared/Styles/Colors.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Styles/Colors.xaml
@@ -1,0 +1,23 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Dark">
+            <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush"
+                             Color="#FF34424d" />
+            <Color x:Key="InfoBarInformationalSeverityIconBackground">#FF5fb2f2</Color>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush"
+                             Color="#FFd3e7f7" />
+            <Color x:Key="InfoBarInformationalSeverityIconBackground">#FF0063b1</Color>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="HighContrast">
+            <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush"
+                             Color="#FF34424d" />
+            <SolidColorBrush x:Key="SolidBackgroundBrush"
+                             Color="Black" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
+</ResourceDictionary>


### PR DESCRIPTION
- Some minor margin tweaks
- Adding an InfoBar that highlights that this is an experiment (in the future we'd have some logic to hide this for a shipped control?) with a link to the wiki page explaining how to configure a preview package feed.

![image](https://user-images.githubusercontent.com/9866362/200302355-c0e89eae-b302-47cc-aa0f-7a629b3bbb62.png)

This links to: https://github.com/CommunityToolkit/WindowsCommunityToolkit/wiki/Preview-Packages#toolkit-labs-

@michael-hawker Love to hear your thoughts on this (and wording :))