### PR TITLE
Bump the RiveSharp NuGet reference to version 1.0.4

### DIFF
--- a/labs/RivePlayer/src/CommunityToolkit.Labs.WinUI.Rive.RivePlayer.csproj
+++ b/labs/RivePlayer/src/CommunityToolkit.Labs.WinUI.Rive.RivePlayer.csproj
@@ -18,7 +18,7 @@
     <Description>
       This package contains RivePlayer.
     </Description>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
   </PropertyGroup>
 
   <!-- XAML Pages are automatically included, and don't need to be specified here. -->

--- a/labs/RivePlayer/src/Dependencies.props
+++ b/labs/RivePlayer/src/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Rive.RiveSharp" Version="1.0.2-alpha.2551e93c0" />
+    <PackageReference Include="Rive.RiveSharp" Version="1.0.4-alpha.fb94cdf8a" />
   </ItemGroup>
 
   <!-- WinUI 2 / UWP -->


### PR DESCRIPTION
Version 1.0.4 is built with Emscripten 2.0.23, which is the correct version for linking with netstandard2.0.