### PR TITLE
[SettingsExpander] Adding ItemsHeader/ItemsFooter property

### DIFF
--- a/labs/SettingsControls/samples/SettingsControls.Samples/ClickableSettingsCardSample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/ClickableSettingsCardSample.xaml
@@ -6,7 +6,7 @@
       xmlns:labs="using:CommunityToolkit.Labs.WinUI"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
-    <StackPanel Spacing="4">
+    <StackPanel Spacing="3">
 
         <labs:SettingsCard x:Name="settingsCard"
                            Description="A SettingsCard can be made clickable and you can leverage the Command property or Click event."

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsCardSample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsCardSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsCardSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,7 +6,7 @@
       xmlns:labs="using:CommunityToolkit.Labs.WinUI"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
-    <StackPanel Spacing="4">
+    <StackPanel Spacing="3">
         <TextBlock Margin="1,0,0,4"
                    Style="{StaticResource BodyStrongTextBlockStyle}"
                    Text="Group of settings" />

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpander.md
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpander.md
@@ -21,6 +21,6 @@ A `SettingsExpander` can have it's own content to display a setting on the right
 
 You can easily override certain properties to create custom experiences. For instance, you can customize the `ContentAlignment` of a `SettingsCard`, to align your content to the Right (default), Left (hiding the `HeaderIcon`, `Header` and `Description`) or Vertically (usually best paired with changing the `HorizontalContentAlignment` to `Stretch`).
 
-`SettingsExpander` is also an `ItemsControl`, so its items can be driven by a collection and the `ItemsSource` property. You can use the `ItemTemplate` to define how your data object is represented as a `SettingsCard`, as shown below. The `Footer` property can be used to host custom content at the end of the items list.
+`SettingsExpander` is also an `ItemsControl`, so its items can be driven by a collection and the `ItemsSource` property. You can use the `ItemTemplate` to define how your data object is represented as a `SettingsCard`, as shown below. The `ItemsHeader` and `ItemsFooter` property can be used to host custom content at the start or end of the items list.
 
 > [!SAMPLE SettingsExpanderItemsSourceSample]

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpander.md
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpander.md
@@ -21,6 +21,6 @@ A `SettingsExpander` can have it's own content to display a setting on the right
 
 You can easily override certain properties to create custom experiences. For instance, you can customize the `ContentAlignment` of a `SettingsCard`, to align your content to the Right (default), Left (hiding the `HeaderIcon`, `Header` and `Description`) or Vertically (usually best paired with changing the `HorizontalContentAlignment` to `Stretch`).
 
-`SettingsExpander` is also an `ItemsControl`, so its items can be driven by a collection and the `ItemsSource` property. You can use the `ItemTemplate` to define how your data object is represented as a `SettingsCard`, as shown here:
+`SettingsExpander` is also an `ItemsControl`, so its items can be driven by a collection and the `ItemsSource` property. You can use the `ItemTemplate` to define how your data object is represented as a `SettingsCard`, as shown below. The `Footer` property can be used to host custom content at the end of the items list.
 
 > [!SAMPLE SettingsExpanderItemsSourceSample]

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpanderItemsSourceSample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpanderItemsSourceSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsExpanderItemsSourceSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,6 +6,7 @@
       xmlns:labs="using:CommunityToolkit.Labs.WinUI"
       xmlns:local="using:SettingsControlsExperiment.Samples"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
 
     <labs:SettingsExpander Description="The SettingsExpander can use ItemsSource to define its Items."
@@ -23,5 +24,16 @@
                 </labs:SettingsCard>
             </DataTemplate>
         </labs:SettingsExpander.ItemTemplate>
+        <labs:SettingsExpander.Footer>
+            <muxc:InfoBar Title="This is the footer"
+                          CornerRadius="0,0,4,4"
+                          IsIconVisible="False"
+                          IsOpen="True"
+                          Severity="Informational">
+                <muxc:InfoBar.ActionButton>
+                    <HyperlinkButton Content="It can host custom content" />
+                </muxc:InfoBar.ActionButton>
+            </muxc:InfoBar>
+        </labs:SettingsExpander.Footer>
     </labs:SettingsExpander>
 </Page>

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpanderItemsSourceSample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsExpanderItemsSourceSample.xaml
@@ -24,8 +24,19 @@
                 </labs:SettingsCard>
             </DataTemplate>
         </labs:SettingsExpander.ItemTemplate>
-        <labs:SettingsExpander.Footer>
-            <muxc:InfoBar Title="This is the footer"
+        <labs:SettingsExpander.ItemsHeader>
+            <muxc:InfoBar Title="This is the ItemsHeader"
+                          CornerRadius="0,0,4,4"
+                          IsIconVisible="False"
+                          IsOpen="True"
+                          Severity="Success">
+                <muxc:InfoBar.ActionButton>
+                    <HyperlinkButton Content="It can host custom content" />
+                </muxc:InfoBar.ActionButton>
+            </muxc:InfoBar>
+        </labs:SettingsExpander.ItemsHeader>
+        <labs:SettingsExpander.ItemsFooter>
+            <muxc:InfoBar Title="This is the ItemsFooter"
                           CornerRadius="0,0,4,4"
                           IsIconVisible="False"
                           IsOpen="True"
@@ -34,6 +45,6 @@
                     <HyperlinkButton Content="It can host custom content" />
                 </muxc:InfoBar.ActionButton>
             </muxc:InfoBar>
-        </labs:SettingsExpander.Footer>
+        </labs:SettingsExpander.ItemsFooter>
     </labs:SettingsExpander>
 </Page>

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsPageExample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsPageExample.xaml
@@ -6,6 +6,17 @@
       xmlns:labs="using:CommunityToolkit.Labs.WinUI"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
+    <Page.Resources>
+        <!--  These styles can be referenced to create a consistent SettingsPage layout  -->
+        <x:Double x:Key="SettingsCardSpacing">3</x:Double>
+        <Style x:Key="SettingsGroupTextBlockStyle"
+               BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+               TargetType="TextBlock">
+            <Style.Setters>
+                <Setter Property="Margin" Value="1,30,0,4" />
+            </Style.Setters>
+        </Style>
+    </Page.Resources>
     <ScrollViewer>
         <StackPanel MaxWidth="1000"
                     HorizontalAlignment="Stretch"

--- a/labs/SettingsControls/samples/SettingsControls.Samples/SettingsPageExample.xaml
+++ b/labs/SettingsControls/samples/SettingsControls.Samples/SettingsPageExample.xaml
@@ -9,10 +9,9 @@
     <ScrollViewer>
         <StackPanel MaxWidth="1000"
                     HorizontalAlignment="Stretch"
-                    Spacing="4">
+                    Spacing="{StaticResource SettingsCardSpacing}">
             <!--  TODO: @Niels - I just copied everything here, not sure if any values need adjusting. We should probably use this as a place to have more bespoke examples of each type of content like Slider, ComboBox, TextBox, etc...  -->
-            <TextBlock Margin="1,0,0,4"
-                       Style="{StaticResource BodyStrongTextBlockStyle}"
+            <TextBlock Style="{StaticResource SettingsGroupTextBlockStyle}"
                        Text="Group of settings" />
             <labs:SettingsCard Description="This is a default card, with the Header, HeaderIcon, Description and Content set."
                                Header="This is the Header">
@@ -55,8 +54,7 @@
                         Style="{StaticResource AccentButtonStyle}" />
             </labs:SettingsCard>
 
-            <TextBlock Margin="1,28,0,4"
-                       Style="{StaticResource BodyStrongTextBlockStyle}"
+            <TextBlock Style="{StaticResource SettingsGroupTextBlockStyle}"
                        Text="Next group of settings" />
 
             <labs:SettingsCard Description="A SettingsCard can be made clickable and you can leverage the Command property or Click event."
@@ -80,8 +78,7 @@
                 </labs:SettingsCard.ActionIcon>
             </labs:SettingsCard>
 
-            <TextBlock Margin="1,28,0,4"
-                       Style="{StaticResource BodyStrongTextBlockStyle}"
+            <TextBlock Style="{StaticResource SettingsGroupTextBlockStyle}"
                        Text="Final group of settings" />
 
             <labs:SettingsExpander Description="The SettingsExpander has the same properties as a Card, and you can set SettingsCard as part of the Items collection."

--- a/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
+++ b/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
+<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
   <!-- Labs Constants -->
   <Import Project="$(RepositoryDirectory)common\Labs.TargetFrameworks.props" />
   <Import Project="$(RepositoryDirectory)common\Labs.ProjectIdentifiers.props" />
@@ -18,7 +18,7 @@
     <Description>
       This package contains the SettingsCard and SettingsExpander controls.
     </Description>
-    <Version>0.0.9</Version>
+    <Version>0.0.10</Version>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -1055,4 +1055,13 @@
             </Setter>
         </Style.Setters>
     </Style>
+
+    <!--  These styles can be referenced to create a consistent SettingsPage layout  -->
+    <x:Double x:Key="SettingsCardSpacing">3</x:Double>
+    <Style x:Key="SettingsGroupTextBlockStyle"
+           BasedOn="{StaticResource BodyStrongTextBlockStyle}">
+        <Style.Setters>
+            <Setter Property="Margin" Value="-1,30,0,4" />
+        </Style.Setters>
+    </Style>
 </ResourceDictionary>

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -1055,13 +1055,4 @@
             </Setter>
         </Style.Setters>
     </Style>
-
-    <!--  These styles can be referenced to create a consistent SettingsPage layout  -->
-    <x:Double x:Key="SettingsCardSpacing">3</x:Double>
-    <Style x:Key="SettingsGroupTextBlockStyle"
-           BasedOn="{StaticResource BodyStrongTextBlockStyle}">
-        <Style.Setters>
-            <Setter Property="Margin" Value="-1,30,0,4" />
-        </Style.Setters>
-    </Style>
 </ResourceDictionary>

--- a/labs/SettingsControls/src/SettingsExpander/SettingsExpander.Properties.cs
+++ b/labs/SettingsControls/src/SettingsExpander/SettingsExpander.Properties.cs
@@ -45,6 +45,15 @@ public partial class SettingsExpander
         new PropertyMetadata(defaultValue: null));
 
     /// <summary>
+    /// The backing <see cref="DependencyProperty"/> for the <see cref="Content"/> property.
+    /// </summary>
+    public static readonly DependencyProperty FooterProperty = DependencyProperty.Register(
+        nameof(Footer),
+        typeof(object),
+        typeof(SettingsExpander),
+        new PropertyMetadata(defaultValue: null));
+
+    /// <summary>
     /// The backing <see cref="DependencyProperty"/> for the <see cref="IsExpanded"/> property.
     /// </summary>
     public static readonly DependencyProperty IsExpandedProperty = DependencyProperty.Register(
@@ -91,6 +100,15 @@ public partial class SettingsExpander
     {
         get => (object)GetValue(ContentProperty);
         set => SetValue(ContentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the Footer.
+    /// </summary>
+    public object Footer
+    {
+        get => (object)GetValue(FooterProperty);
+        set => SetValue(FooterProperty, value);
     }
 
     /// <summary>

--- a/labs/SettingsControls/src/SettingsExpander/SettingsExpander.Properties.cs
+++ b/labs/SettingsControls/src/SettingsExpander/SettingsExpander.Properties.cs
@@ -49,7 +49,7 @@ public partial class SettingsExpander
     /// </summary>
     public static readonly DependencyProperty FooterProperty = DependencyProperty.Register(
         nameof(Footer),
-        typeof(object),
+        typeof(UIElement),
         typeof(SettingsExpander),
         new PropertyMetadata(defaultValue: null));
 
@@ -105,9 +105,9 @@ public partial class SettingsExpander
     /// <summary>
     /// Gets or sets the Footer.
     /// </summary>
-    public object Footer
+    public UIElement Footer
     {
-        get => (object)GetValue(FooterProperty);
+        get => (UIElement)GetValue(FooterProperty);
         set => SetValue(FooterProperty, value);
     }
 

--- a/labs/SettingsControls/src/SettingsExpander/SettingsExpander.Properties.cs
+++ b/labs/SettingsControls/src/SettingsExpander/SettingsExpander.Properties.cs
@@ -47,8 +47,17 @@ public partial class SettingsExpander
     /// <summary>
     /// The backing <see cref="DependencyProperty"/> for the <see cref="Content"/> property.
     /// </summary>
-    public static readonly DependencyProperty FooterProperty = DependencyProperty.Register(
-        nameof(Footer),
+    public static readonly DependencyProperty ItemsHeaderProperty = DependencyProperty.Register(
+        nameof(ItemsHeader),
+        typeof(UIElement),
+        typeof(SettingsExpander),
+        new PropertyMetadata(defaultValue: null));
+
+    /// <summary>
+    /// The backing <see cref="DependencyProperty"/> for the <see cref="Content"/> property.
+    /// </summary>
+    public static readonly DependencyProperty ItemsFooterProperty = DependencyProperty.Register(
+        nameof(ItemsFooter),
         typeof(UIElement),
         typeof(SettingsExpander),
         new PropertyMetadata(defaultValue: null));
@@ -103,12 +112,21 @@ public partial class SettingsExpander
     }
 
     /// <summary>
-    /// Gets or sets the Footer.
+    /// Gets or sets the ItemsFooter.
     /// </summary>
-    public UIElement Footer
+    public UIElement ItemsHeader
     {
-        get => (UIElement)GetValue(FooterProperty);
-        set => SetValue(FooterProperty, value);
+        get => (UIElement)GetValue(ItemsHeaderProperty);
+        set => SetValue(ItemsHeaderProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the ItemsFooter.
+    /// </summary>
+    public UIElement ItemsFooter
+    {
+        get => (UIElement)GetValue(ItemsFooterProperty);
+        set => SetValue(ItemsFooterProperty, value);
     }
 
     /// <summary>

--- a/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
+++ b/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
@@ -89,7 +89,10 @@
                                                    IsClickEnabled="False" />
                             </muxc:Expander.Header>
                             <muxc:Expander.Content>
-                                <ItemsPresenter TabFocusNavigation="Local" />
+                                <StackPanel>
+                                    <ItemsPresenter TabFocusNavigation="Local" />
+                                    <ContentPresenter Content="{TemplateBinding Footer}" />
+                                </StackPanel>
                             </muxc:Expander.Content>
                         </muxc:Expander>
                     </ControlTemplate>

--- a/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
+++ b/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
@@ -89,8 +89,8 @@
                                                    IsClickEnabled="False" />
                             </muxc:Expander.Header>
                             <muxc:Expander.Content>
-                                <ItemsPresenter Footer="{TemplateBinding ItemsFooter}"
-                                                Header="{TemplateBinding ItemsHeader}"
+                                <ItemsPresenter win:Footer="{TemplateBinding ItemsFooter}"
+                                                win:Header="{TemplateBinding ItemsHeader}"
                                                 TabFocusNavigation="Local" />
                             </muxc:Expander.Content>
                         </muxc:Expander>

--- a/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
+++ b/labs/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
@@ -89,10 +89,9 @@
                                                    IsClickEnabled="False" />
                             </muxc:Expander.Header>
                             <muxc:Expander.Content>
-                                <StackPanel>
-                                    <ItemsPresenter TabFocusNavigation="Local" />
-                                    <ContentPresenter Content="{TemplateBinding Footer}" />
-                                </StackPanel>
+                                <ItemsPresenter Footer="{TemplateBinding ItemsFooter}"
+                                                Header="{TemplateBinding ItemsHeader}"
+                                                TabFocusNavigation="Local" />
                             </muxc:Expander.Content>
                         </muxc:Expander>
                     </ControlTemplate>


### PR DESCRIPTION
This PR introduces a ItemsHeader/ItemsFooter property, a way to host custom content add the top or bottom of a SettingsExpander. This is a common practice across W11 Settings to e.g. visualize links or other messages.

```xml
<labs:SettingsExpander.ItemsFooter>
     <muxc:InfoBar Title="This is the footer">
          <muxc:InfoBar.ActionButton>
               <HyperlinkButton Content="It can host custom content" />
          </muxc:InfoBar.ActionButton>
     </muxc:InfoBar>
</labs:SettingsExpander.ItemsFooter>
```

Result:
![Footer2](https://user-images.githubusercontent.com/9866362/206426282-ca9168ed-fa94-4890-adae-97e849d66150.gif)

