### PR TITLE
Updated workflow versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "uno.check": {
-      "version": "1.3.1",
+      "version": "1.10.0",
       "commands": [
         "uno-check"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools
@@ -54,13 +54,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.202'
+          dotnet-version: '6.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Restore Tools from Manifest list in the Repository
       - name: Restore dotnet tools
@@ -134,13 +134,13 @@ jobs:
 
     steps:
       - name: Install .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.202'
+          dotnet-version: '6.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.3
@@ -191,13 +191,13 @@ jobs:
 
     steps:
       - name: Install .NET 6 SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.201'
+          dotnet-version: '6.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate solution
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,6 @@ jobs:
       # See launch.json configuration file for analogous command we're emulating here to build LINK: ../../.vscode/launch.json:CommunityToolkit.Labs.Wasm.csproj
       - name: dotnet build
         working-directory: ./platforms/CommunityToolkit.Labs.Wasm/
-        run: dotnet build /r /bl /p:UnoSourceGeneratorUseGenerationHost=true /p:UnoSourceGeneratorUseGenerationController=false -p:TargetFrameworks=netstandard2.0 -p:TargetFramework=net5.0
+        run: dotnet build /r /bl /p:UnoSourceGeneratorUseGenerationHost=true /p:UnoSourceGeneratorUseGenerationController=false
   
       # TODO: Do we want to run tests here? Can we do that on linux easily?

--- a/common/Labs.Head.WinAppSdk.props
+++ b/common/Labs.Head.WinAppSdk.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/common/Labs.Head.WinAppSdk.props
+++ b/common/Labs.Head.WinAppSdk.props
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/common/MultiTarget/MultiTarget.props
+++ b/common/MultiTarget/MultiTarget.props
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' == '$(UwpTargetFramework)'" Include="Microsoft.UI.Xaml" Version="2.7.0" />
-    <PackageReference Condition="'$(TargetFramework)' == '$(WinAppSdkTargetFramework)'" Include="Microsoft.WindowsAppSDK" Version="1.0.3" />
+    <PackageReference Condition="'$(TargetFramework)' == '$(WinAppSdkTargetFramework)'" Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,10 @@
 {
-    "msbuild-sdks": 
-    {
-        "MSBuild.Sdk.Extras":"3.0.23"
-    }
+  "sdk": {
+    "version": "6.0.403",
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": 
+  {
+    "MSBuild.Sdk.Extras":"3.0.23"
+  }
 }


### PR DESCRIPTION
This PR closes #337

- Updated all `actions/*` in build workflow to be on v3
- Use dotnet-version: '6.0.x' for .NET versions
- Updated Windows App SDK to 1.2.221209.1