### PR TITLE
[SettingsControls] Minor UI tweaks

### DIFF
--- a/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
+++ b/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
@@ -18,7 +18,7 @@
     <Description>
       This package contains the SettingsCard and SettingsExpander controls.
     </Description>
-    <Version>0.0.11</Version>
+    <Version>0.0.12</Version>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -322,6 +322,7 @@
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="Left" />
                                             <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
+                                            <Setter Target="HeaderPanel.Margin" Value="0" />
                                         </VisualState.Setters>
                                     </VisualState>
                                     <VisualState x:Name="RightWrappedNoIcon">
@@ -336,6 +337,7 @@
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Stretch" />
                                             <Setter Target="PART_ContentPresenter.HorizontalContentAlignment" Value="Left" />
                                             <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource SettingsCardVerticalHeaderContentSpacing}" />
+                                            <Setter Target="HeaderPanel.Margin" Value="0" />
                                         </VisualState.Setters>
                                     </VisualState>
                                     <VisualState x:Name="Vertical">
@@ -364,8 +366,9 @@
                                                   Content="{TemplateBinding HeaderIcon}" />
                             </Viewbox>
 
-                            <StackPanel Grid.Column="1"
-                                        Margin="0,0,12,0"
+                            <StackPanel x:Name="HeaderPanel"
+                                        Grid.Column="1"
+                                        Margin="0,0,24,0"
                                         VerticalAlignment="Center"
                                         Orientation="Vertical">
                                 <ContentPresenter x:Name="PART_HeaderPresenter"
@@ -408,7 +411,6 @@
 
                             <ContentPresenter x:Name="PART_ContentPresenter"
                                               Grid.Column="2"
-                                              MinWidth="{ThemeResource SettingsCardContentMinWidth}"
                                               HorizontalAlignment="Right"
                                               VerticalAlignment="Center"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
@@ -305,8 +305,8 @@
                                             <Setter Target="PART_HeaderIconPresenterHolder.Visibility" Value="Collapsed" />
                                             <Setter Target="PART_DescriptionPresenter.Visibility" Value="Collapsed" />
                                             <Setter Target="PART_HeaderPresenter.Visibility" Value="Collapsed" />
-                                            <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="0" />
-                                            <Setter Target="PART_ActionIconPresenter.(Grid.Row)" Value="0" />
+                                            <Setter Target="PART_ContentPresenter.(Grid.Row)" Value="1" />
+                                            <Setter Target="PART_ContentPresenter.(Grid.Column)" Value="1" />
                                             <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Left" />
                                         </VisualState.Setters>
                                     </VisualState>


### PR DESCRIPTION
Related to #216

### 1. ContentAlignment stretching
When the ContentAlignment is set to Left on a SettingsCard, its content would be cut off:
<img width="465" alt="image" src="https://user-images.githubusercontent.com/9866362/210999625-c3f59761-542e-48de-a62e-0191767aa56e.png">


This PR fixes this so it wraps as expected:

<img width="351" alt="image" src="https://user-images.githubusercontent.com/9866362/210998909-af4b5b5f-6404-49f4-9ccb-a0f7b1d84476.png">

### 2. Header/Description does not stretch correctly
<img width="407" alt="image" src="https://user-images.githubusercontent.com/9866362/211001850-4d9d6995-c83c-4c8d-9a1b-ee10b4c54edb.png">

This is because we were still setting the MinWidth of the ContentPresenter - which shouldn't happen. (This was something that should have been removed after we got the styles override to work)

### 3.  Header panel / content spacing incorrect
This should be 24 instead of 12px. And when in one of the Wrapped states, it should be 0 so it can stretch to the entire width.
![image](https://user-images.githubusercontent.com/9866362/211037438-59e83254-26bc-4300-b579-1bc0539bdec1.png)

