### PR TITLE
Fix issued with MultiTarget.props being ignored in Experiments

### DIFF
--- a/common/MultiTarget/MultiTarget.props
+++ b/common/MultiTarget/MultiTarget.props
@@ -3,12 +3,13 @@
     <MultiTargetIsSampleProject Condition="$(MSBuildProjectName.EndsWith('.Samples')) == 'true'">true</MultiTargetIsSampleProject>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)\Defaults.props" Condition="'$(MultiTarget)' == ''" />
   <Import Project="$(MSBuildProjectDirectory)\MultiTarget.props" Condition="Exists('$(MSBuildProjectDirectory)\MultiTarget.props') AND '$(MultiTarget)' == ''" />
 
   <!-- If in a sample project, pull the MultiTarget settings from the source project. -->
   <!-- This behavior is also implemented in GeneratedAllProjectReferences.ps1 for <ProjectReference> generation. -->
-  <Import Project="../../src/MultiTarget.props" Condition="$(MultiTargetIsSampleProject) == 'true' AND !Exists('$(MSBuildProjectDirectory)\MultiTarget.props') AND Exists('../../src/MultiTarget.props')" />
+  <Import Project="../../src/MultiTarget.props" Condition="$(MultiTargetIsSampleProject) == 'true' AND !Exists('$(MSBuildProjectDirectory)\MultiTarget.props') AND Exists('../../src/MultiTarget.props') AND '$(MultiTarget)' == ''" />
+  
+  <Import Project="$(MSBuildThisFileDirectory)\Defaults.props" Condition="'$(MultiTarget)' == ''" />
 
   <PropertyGroup>
     <!--


### PR DESCRIPTION
Discovered while porting and working on TransitionHelper, checked binlog and tested moving import order.