### PR TITLE
[Gallery] UI tweaks

### DIFF
--- a/common/CommunityToolkit.Labs.Shared/AppLoadingView.xaml.cs
+++ b/common/CommunityToolkit.Labs.Shared/AppLoadingView.xaml.cs
@@ -85,14 +85,14 @@ public sealed partial class AppLoadingView : Page
             return;
         }
 
-//#if LABS_ALL_SAMPLES
-//        ScheduleNavigate(typeof(Shell), sampleDocs);
-//#else
+#if LABS_ALL_SAMPLES
+        ScheduleNavigate(typeof(Shell), sampleDocs);
+#else
         var samples = FindReferencedSamples().ToArray();
 
         (IEnumerable<ToolkitSampleMetadata> Samples, IEnumerable<ToolkitFrontMatter> Docs, bool AreDocsFirst) displayInfo = (samples, sampleDocs, false);
         ScheduleNavigate(typeof(TabbedPage), displayInfo);
-//#endif
+#endif
     }
 
     // Needed because Frame.Navigate doesn't work inside of the OnNavigatedTo override.

--- a/common/CommunityToolkit.Labs.Shared/AppLoadingView.xaml.cs
+++ b/common/CommunityToolkit.Labs.Shared/AppLoadingView.xaml.cs
@@ -85,14 +85,14 @@ public sealed partial class AppLoadingView : Page
             return;
         }
 
-#if LABS_ALL_SAMPLES
-        ScheduleNavigate(typeof(Shell), sampleDocs);
-#else
+//#if LABS_ALL_SAMPLES
+//        ScheduleNavigate(typeof(Shell), sampleDocs);
+//#else
         var samples = FindReferencedSamples().ToArray();
 
         (IEnumerable<ToolkitSampleMetadata> Samples, IEnumerable<ToolkitFrontMatter> Docs, bool AreDocsFirst) displayInfo = (samples, sampleDocs, false);
         ScheduleNavigate(typeof(TabbedPage), displayInfo);
-#endif
+//#endif
     }
 
     // Needed because Frame.Navigate doesn't work inside of the OnNavigatedTo override.

--- a/common/CommunityToolkit.Labs.Shared/Pages/Shell.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Pages/Shell.xaml
@@ -20,7 +20,6 @@
                            Icon="ms-appx:///Assets/AppTitleBar.png" />
         <muxc:NavigationView x:Name="NavView"
                              Grid.Row="1"
-                             IsSettingsVisible="False"
                              Margin="0,16,0,0"
                              IsBackButtonVisible="Collapsed"
                              ItemInvoked="NavView_ItemInvoked">

--- a/common/CommunityToolkit.Labs.Shared/Pages/Shell.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Pages/Shell.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="CommunityToolkit.Labs.Shared.Pages.Shell"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -20,6 +20,7 @@
                            Icon="ms-appx:///Assets/AppTitleBar.png" />
         <muxc:NavigationView x:Name="NavView"
                              Grid.Row="1"
+                             IsSettingsVisible="False"
                              Margin="0,16,0,0"
                              IsBackButtonVisible="Collapsed"
                              ItemInvoked="NavView_ItemInvoked">

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml
@@ -21,7 +21,7 @@
             <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal">
                     <VisualState.Setters>
-                        <!--<Setter Target="PageControl.MaxHeight" Value="400" />-->
+                        <Setter Target="PageControl.MaxHeight" Value="600" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Tabbed">
@@ -52,7 +52,6 @@
                         <Setter Target="OptionsPanel.BorderThickness" Value="0,1,0,0" />
                         <Setter Target="FixedOptionsBar.BorderThickness" Value="0" />
                         <Setter Target="ThemeBG.CornerRadius" Value="0" />
-                        <Setter Target="PageControl.Padding" Value="16,16,16,32" />
                         <Setter Target="ThemeBtn.(Grid.Row)" Value="0" />
                         <Setter Target="FlowDirectionBtn.(Grid.Row)" Value="0" />
                         <Setter Target="CodeBtn.(Grid.Row)" Value="0" />
@@ -60,6 +59,10 @@
                         <Setter Target="FlowDirectionBtn.(Grid.Column)" Value="1" />
                         <Setter Target="CodeBtn.(Grid.Column)" Value="2" />
                         <Setter Target="CodePivot.Margin" Value="6,0,8,0" />
+                        <Setter Target="FixedOptionsBar.ColumnSpacing" Value="8" />
+                        <Setter Target="FixedOptionsBar.RowSpacing" Value="0" />
+                        <Setter Target="FixedOptionsBar.Margin" Value="12" />
+
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -91,13 +94,22 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-
+                <ScrollViewer x:Name="OptionsScrollViewer"
+                              Grid.Row="0"
+                              Grid.Column="0"
+                              MinWidth="256"
+                              Padding="16">
+                    <ContentControl x:Name="OptionsControl"
+                                    Content="{x:Bind SampleOptionsPaneInstance, Mode=OneWay}" />
+                </ScrollViewer>
                 <Grid x:Name="FixedOptionsBar"
                       Grid.Column="1"
+                      Padding="4"
                       HorizontalAlignment="Right"
                       Background="{ThemeResource LayerFillColorAltBrush}"
                       BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                      BorderThickness="1,0,0,0">
+                      BorderThickness="1,0,0,0"
+                      RowSpacing="8">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
@@ -108,50 +120,55 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <AppBarButton x:Name="ThemeBtn"
-                                  Grid.Row="0"
-                                  Click="ThemeBtn_OnClick"
-                                  Label="Toggle theme"
-                                  LabelPosition="Collapsed"
-                                  Style="{StaticResource SmallAppBarButtonStyle}"
-                                  ToolTipService.ToolTip="Toggle theme">
-                        <AppBarButton.Icon>
-                            <FontIcon Glyph="&#xE793;" />
-                        </AppBarButton.Icon>
-                    </AppBarButton>
+                    <Button x:Name="ThemeBtn"
+                            Grid.Row="0"
+                            Width="32"
+                            Height="32"
+                            Padding="4"
+                            HorizontalAlignment="Center"
+                            Click="ThemeBtn_OnClick"
+                            Style="{StaticResource SubtleButtonStyle}"
+                            ToolTipService.ToolTip="Toggle theme">
+                        <Button.Content>
+                            <FontIcon FontSize="16"
+                                      Glyph="&#xE793;" />
+                        </Button.Content>
+                    </Button>
 
-                    <AppBarButton x:Name="FlowDirectionBtn"
-                                  Grid.Row="1"
-                                  wasm:Visibility="Collapsed"
-                                  Click="FlowDirectionBtn_OnClick"
-                                  Label="Toggle direction"
-                                  LabelPosition="Collapsed"
-                                  Style="{StaticResource SmallAppBarButtonStyle}"
-                                  ToolTipService.ToolTip="Toggle right-to-left">
-                        <AppBarButton.Icon>
-                            <FontIcon Glyph="&#xE1A0;" />
-                        </AppBarButton.Icon>
-                    </AppBarButton>
+                    <Button x:Name="FlowDirectionBtn"
+                            Grid.Row="1"
+                            Width="32"
+                            Height="32"
+                            Padding="4"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Top"
+                            wasm:Visibility="Collapsed"
+                            Click="FlowDirectionBtn_OnClick"
+                            Style="{StaticResource SubtleButtonStyle}"
+                            ToolTipService.ToolTip="Toggle right-to-left">
 
-                    <AppBarButton x:Name="CodeBtn"
-                                  Grid.Row="2"
-                                  Click="CodeBtn_OnClick"
-                                  Label="View code"
-                                  LabelPosition="Collapsed"
-                                  Style="{StaticResource SmallAppBarButtonStyle}"
-                                  ToolTipService.ToolTip="View code">
-                        <AppBarButton.Icon>
-                            <FontIcon Glyph="&#xE943;" />
-                        </AppBarButton.Icon>
-                    </AppBarButton>
+                        <Button.Content>
+                            <FontIcon FontSize="16"
+                                      Glyph="&#xE1A0;" />
+                        </Button.Content>
+                    </Button>
+
+                    <Button x:Name="CodeBtn"
+                            Grid.Row="2"
+                            Width="32"
+                            Height="32"
+                            Padding="4"
+                            HorizontalAlignment="Center"
+                            Click="CodeBtn_OnClick"
+                            Style="{StaticResource AccentButtonStyle}"
+                            ToolTipService.ToolTip="View code">
+                        <Button.Content>
+                            <FontIcon FontSize="14"
+                                      Glyph="&#xE943;" />
+                        </Button.Content>
+                    </Button>
                 </Grid>
-                <ContentControl x:Name="OptionsControl"
-                                Grid.Row="0"
-                                Grid.Column="0"
-                                MinWidth="256"
-                                Margin="16"
-                                HorizontalAlignment="Left"
-                                Content="{x:Bind SampleOptionsPaneInstance, Mode=OneWay}" />
+
             </Grid>
 
             <Grid x:Name="ContentPageHolder"
@@ -161,12 +178,18 @@
                         Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
                         CornerRadius="8,0,0,8"
                         Visibility="Collapsed" />
-                <ContentControl x:Name="PageControl"
-                                Padding="24,24,32,24"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                HorizontalContentAlignment="Stretch"
-                                Content="{x:Bind SampleControlInstance, Mode=OneWay}" />
+                <ScrollViewer HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch"
+                              HorizontalContentAlignment="Stretch">
+
+                    <ContentControl x:Name="PageControl"
+                                    Margin="16"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
+                                    Background="Yellow"
+                                    Content="{x:Bind SampleControlInstance, Mode=OneWay}" />
+                </ScrollViewer>
             </Grid>
 
             <muxc:Expander x:Name="SourcecodeExpander"
@@ -199,6 +222,7 @@
                             <ScrollViewer>
                                 <TextBlock wasm:IsTextSelectionEnabled="True"
                                            win:IsTextSelectionEnabled="True"
+                                           Style="{StaticResource CaptionTextBlockStyle}"
                                            Text="{x:Bind XamlCode, Mode=OneWay}" />
                             </ScrollViewer>
                         </PivotItem>
@@ -206,6 +230,7 @@
                             <ScrollViewer>
                                 <TextBlock wasm:IsTextSelectionEnabled="True"
                                            win:IsTextSelectionEnabled="True"
+                                           Style="{StaticResource CaptionTextBlockStyle}"
                                            Text="{x:Bind CSharpCode, Mode=OneWay}" />
                             </ScrollViewer>
                         </PivotItem>

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="CommunityToolkit.Labs.Shared.Renderers.ToolkitSampleRenderer"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -21,14 +21,12 @@
             <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal">
                     <VisualState.Setters>
-                        <Setter Target="PageControl.MaxHeight" Value="400" />
+                        <!--<Setter Target="PageControl.MaxHeight" Value="400" />-->
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Tabbed">
                     <VisualState.Setters>
-                        <Setter Target="ToolBar.DefaultLabelPosition" Value="Right" />
                         <Setter Target="CodeBtn.Visibility" Value="Collapsed" />
-                        <Setter Target="SeperatorLine.Visibility" Value="Collapsed" />
                         <Setter Target="SourcecodeExpander.Visibility" Value="Collapsed" />
                         <Setter Target="SampleCard.BorderThickness" Value="0" />
                         <Setter Target="SampleCard.CornerRadius" Value="0" />
@@ -38,12 +36,12 @@
             </VisualStateGroup>
 
             <VisualStateGroup x:Name="OrientationStates">
-                <VisualState x:Name="HorizontalSampleLayout">
+                <VisualState x:Name="DefaultLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource Breakpoint1008Plus}" />
                     </VisualState.StateTriggers>
                 </VisualState>
-                <VisualState x:Name="VerticalSampleLayout">
+                <VisualState x:Name="VerticalLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource Breakpoint641Plus}" />
                         <AdaptiveTrigger MinWindowWidth="0" />
@@ -51,9 +49,17 @@
                     <VisualState.Setters>
                         <Setter Target="OptionsPanel.(Grid.Row)" Value="1" />
                         <Setter Target="OptionsPanel.(Grid.Column)" Value="0" />
-                        <Setter Target="ToolBar.(Grid.Row)" Value="1" />
+                        <Setter Target="OptionsPanel.BorderThickness" Value="0,1,0,0" />
+                        <Setter Target="FixedOptionsBar.BorderThickness" Value="0" />
                         <Setter Target="ThemeBG.CornerRadius" Value="0" />
                         <Setter Target="PageControl.Padding" Value="16,16,16,32" />
+                        <Setter Target="ThemeBtn.(Grid.Row)" Value="0" />
+                        <Setter Target="FlowDirectionBtn.(Grid.Row)" Value="0" />
+                        <Setter Target="CodeBtn.(Grid.Row)" Value="0" />
+                        <Setter Target="ThemeBtn.(Grid.Column)" Value="0" />
+                        <Setter Target="FlowDirectionBtn.(Grid.Column)" Value="1" />
+                        <Setter Target="CodeBtn.(Grid.Column)" Value="2" />
+                        <Setter Target="CodePivot.Margin" Value="6,0,8,0" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -68,6 +74,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
@@ -77,20 +84,35 @@
             <Grid x:Name="OptionsPanel"
                   Grid.Column="1"
                   VerticalAlignment="Stretch"
-                  Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+                  Background="{ThemeResource LayerFillColorDefaultBrush}"
                   BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                   BorderThickness="1,0,0,0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-                <CommandBar x:Name="ToolBar"
-                            DefaultLabelPosition="Collapsed"
-                            OverflowButtonVisibility="Collapsed">
-                    <!--  wasm:Visibility="Collapsed"  -->
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Grid x:Name="FixedOptionsBar"
+                      Grid.Column="1"
+                      HorizontalAlignment="Right"
+                      Background="{ThemeResource LayerFillColorAltBrush}"
+                      BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                      BorderThickness="1,0,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
                     <AppBarButton x:Name="ThemeBtn"
+                                  Grid.Row="0"
                                   Click="ThemeBtn_OnClick"
                                   Label="Toggle theme"
+                                  LabelPosition="Collapsed"
                                   Style="{StaticResource SmallAppBarButtonStyle}"
                                   ToolTipService.ToolTip="Toggle theme">
                         <AppBarButton.Icon>
@@ -98,98 +120,98 @@
                         </AppBarButton.Icon>
                     </AppBarButton>
 
-                    <!--  wasm:Visibility="Collapsed"  -->
                     <AppBarButton x:Name="FlowDirectionBtn"
+                                  Grid.Row="1"
+                                  wasm:Visibility="Collapsed"
                                   Click="FlowDirectionBtn_OnClick"
                                   Label="Toggle direction"
+                                  LabelPosition="Collapsed"
                                   Style="{StaticResource SmallAppBarButtonStyle}"
                                   ToolTipService.ToolTip="Toggle right-to-left">
                         <AppBarButton.Icon>
                             <FontIcon Glyph="&#xE1A0;" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                    <AppBarSeparator x:Name="SeperatorLine" />
+
                     <AppBarButton x:Name="CodeBtn"
+                                  Grid.Row="2"
                                   Click="CodeBtn_OnClick"
                                   Label="View code"
+                                  LabelPosition="Collapsed"
                                   Style="{StaticResource SmallAppBarButtonStyle}"
                                   ToolTipService.ToolTip="View code">
                         <AppBarButton.Icon>
                             <FontIcon Glyph="&#xE943;" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                    <!--  TO DO: What URL to link to?  -->
-                    <!--<AppBarButton x:Name="GitHubBtn"
-                                      ToolTipService.ToolTip="View sample on GitHub"
-                                      Visibility="Collapsed"
-                                      Style="{StaticResource SmallAppBarButtonStyle}">
-                            <AppBarButton.Icon>
-                                <PathIcon Data="{StaticResource GithubIcon}" />
-                            </AppBarButton.Icon>
-                        </AppBarButton>-->
-                </CommandBar>
-
-
-                <Rectangle Height="1"
-                           VerticalAlignment="Bottom"
-                           Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
+                </Grid>
                 <ContentControl x:Name="OptionsControl"
-                                Grid.Row="1"
-                                MinWidth="240"
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                MinWidth="256"
                                 Margin="16"
                                 HorizontalAlignment="Left"
                                 Content="{x:Bind SampleOptionsPaneInstance, Mode=OneWay}" />
             </Grid>
 
-
-            <Grid x:Name="ContentPageHolder">
+            <Grid x:Name="ContentPageHolder"
+                  Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
                 <!--  A solidbackground we enable when toggling themes. WinUI uses a lot of translucent brushes and might look weird  -->
                 <Border x:Name="ThemeBG"
                         Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
                         CornerRadius="8,0,0,8"
                         Visibility="Collapsed" />
                 <ContentControl x:Name="PageControl"
-                                Grid.Row="1"
-                                Padding="16,16,32,16"
+                                Padding="24,24,32,24"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
                                 Content="{x:Bind SampleControlInstance, Mode=OneWay}" />
             </Grid>
+
+            <muxc:Expander x:Name="SourcecodeExpander"
+                           Grid.Row="2"
+                           Grid.ColumnSpan="3"
+                           MinHeight="0"
+                           Margin="0,-1,0,0"
+                           Padding="0,0,0,0"
+                           HorizontalAlignment="Stretch"
+                           BorderBrush="Transparent"
+                           BorderThickness="0,1,0,0"
+                           CornerRadius="0,0,8,8">
+                <muxc:Expander.Resources>
+                    <x:Double x:Key="ExpanderChevronButtonSize">0</x:Double>
+                    <Thickness x:Key="ExpanderHeaderBorderThickness">0,0,0,0</Thickness>
+                    <StaticResource x:Key="ExpanderContentBackground"
+                                    ResourceKey="LayerFillColorDefaultBrush" />
+                </muxc:Expander.Resources>
+                <Grid BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                      BorderThickness="0,1,0,0">
+                    <Pivot x:Name="CodePivot"
+                           MaxHeight="400"
+                           Margin="16,0,16,0"
+                           HorizontalAlignment="Stretch">
+                        <Pivot.Resources>
+                            <x:Double x:Key="PivotHeaderItemFontSize">14</x:Double>
+                        </Pivot.Resources>
+
+                        <PivotItem Header="XAML">
+                            <ScrollViewer>
+                                <TextBlock wasm:IsTextSelectionEnabled="True"
+                                           win:IsTextSelectionEnabled="True"
+                                           Text="{x:Bind XamlCode, Mode=OneWay}" />
+                            </ScrollViewer>
+                        </PivotItem>
+                        <PivotItem Header="C#">
+                            <ScrollViewer>
+                                <TextBlock wasm:IsTextSelectionEnabled="True"
+                                           win:IsTextSelectionEnabled="True"
+                                           Text="{x:Bind CSharpCode, Mode=OneWay}" />
+                            </ScrollViewer>
+                        </PivotItem>
+                    </Pivot>
+                </Grid>
+            </muxc:Expander>
         </Grid>
-
-        <muxc:Expander x:Name="SourcecodeExpander"
-                       Grid.Row="2"
-                       MinHeight="0"
-                       Margin="0,-1,0,0"
-                       Padding="16,0,16,0"
-                       HorizontalAlignment="Stretch"
-                       BorderThickness="0">
-            <muxc:Expander.Resources>
-                <x:Double x:Key="ExpanderChevronButtonSize">0</x:Double>
-                <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
-            </muxc:Expander.Resources>
-            <Pivot MaxHeight="400"
-                   HorizontalAlignment="Stretch">
-                <Pivot.Resources>
-                    <x:Double x:Key="PivotHeaderItemFontSize">14</x:Double>
-                </Pivot.Resources>
-
-                <PivotItem Header="XAML">
-                    <ScrollViewer>
-                        <TextBlock wasm:IsTextSelectionEnabled="True"
-                                   win:IsTextSelectionEnabled="True"
-                                   Text="{x:Bind XamlCode, Mode=OneWay}" />
-                    </ScrollViewer>
-                </PivotItem>
-                <PivotItem Header="C#">
-                    <ScrollViewer>
-                        <TextBlock wasm:IsTextSelectionEnabled="True"
-                                   win:IsTextSelectionEnabled="True"
-                                   Text="{x:Bind CSharpCode, Mode=OneWay}" />
-                    </ScrollViewer>
-                </PivotItem>
-            </Pivot>
-        </muxc:Expander>
     </Grid>
 </Page>

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -176,7 +176,7 @@ public sealed partial class ToolkitSampleRenderer : Page
         }
         else
         {
-            OptionsControl.Visibility = Visibility.Collapsed;
+            OptionsScrollViewer.Visibility = Visibility.Collapsed;
         }
 
         // Generated options must be assigned before attempting to render the control,

--- a/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/common/CommunityToolkit.Labs.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -156,13 +156,12 @@ public sealed partial class ToolkitSampleRenderer : Page
         CSharpCode = await GetMetadataFileContents(Metadata, "xaml.cs");
 
         var sampleControlInstance = (UIElement)Metadata.SampleControlFactory();
-       
+
         // Custom control-based sample options.
         if (Metadata.SampleOptionsPaneType is not null && Metadata.SampleOptionsPaneFactory is not null)
         {
             SampleOptionsPaneInstance = (UIElement)Metadata.SampleOptionsPaneFactory(sampleControlInstance);
         }
-
         // Source generater-based sample options
         else if (sampleControlInstance is IToolkitSampleGeneratedOptionPropertyContainer propertyContainer)
         {
@@ -174,6 +173,10 @@ public sealed partial class ToolkitSampleRenderer : Page
             {
                 SampleOptions = propertyContainer.GeneratedPropertyMetadata
             };
+        }
+        else
+        {
+            OptionsControl.Visibility = Visibility.Collapsed;
         }
 
         // Generated options must be assigned before attempting to render the control,

--- a/common/CommunityToolkit.Labs.Shared/Styles/Buttons.xaml
+++ b/common/CommunityToolkit.Labs.Shared/Styles/Buttons.xaml
@@ -348,9 +348,5 @@
         <!--<Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />-->
     </Style>
 
-    <Style x:Key="SmallAppBarButtonStyle"
-           BasedOn="{StaticResource DefaultAppBarButtonStyle}"
-           TargetType="AppBarButton">
-        <Setter Property="Width" Value="36" />
-    </Style>
+
 </ResourceDictionary>


### PR DESCRIPTION
This PR optimizes the sample renderer layout. It increases the default MaxWidth to 600, introduces a ScrollViewer so that samples can be scrolled and optimizes the options layout so it auto collapsed whenever no sample options are defined.

With options
![image](https://user-images.githubusercontent.com/9866362/212075319-f017ffe3-99c1-4023-a26b-255ccd081bee.png)

No settings defined:
![image](https://user-images.githubusercontent.com/9866362/212075448-0c1a0e51-0012-47ac-965a-c6f52499dc22.png)