### PR TITLE
[SettingsControls] A11y bugfix + visual update

### DIFF
--- a/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
+++ b/labs/SettingsControls/src/CommunityToolkit.Labs.WinUI.SettingsControls.csproj
@@ -18,7 +18,7 @@
     <Description>
       This package contains the SettingsCard and SettingsExpander controls.
     </Description>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -53,7 +53,7 @@ public partial class SettingsCard : ButtonBase
         {
             AutomationProperties.SetName(this, headerString);
             // We don't want to override an AutomationProperties.Name that is manually set, or if the Content basetype is of type ButtonBase (the ButtonBase.Content will be used then)
-            if (Content is UIElement element && string.IsNullOrEmpty(AutomationProperties.GetName(element)) && element.GetType().BaseType != typeof(ButtonBase))
+            if (Content is UIElement element && string.IsNullOrEmpty(AutomationProperties.GetName(element)) && element.GetType().BaseType != typeof(ButtonBase) && element.GetType() != typeof(TextBlock))
             {
                 AutomationProperties.SetName(element, headerString);
             }

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -459,15 +459,11 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ToggleSwitch">
-                        <Grid VerticalAlignment="Center"
+                        <Grid VerticalAlignment="Stretch"
                               Background="{TemplateBinding Background}"
                               BorderBrush="{TemplateBinding BorderBrush}"
                               BorderThickness="{TemplateBinding BorderThickness}"
                               CornerRadius="{TemplateBinding CornerRadius}">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">
                                     <VisualState x:Name="Normal">
@@ -956,12 +952,7 @@
                                               Visibility="Collapsed" />
                             <Grid Grid.Row="1"
                                   HorizontalAlignment="Right"
-                                  VerticalAlignment="Top">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="{ThemeResource ToggleSwitchPreContentMargin}" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="{ThemeResource ToggleSwitchPostContentMargin}" />
-                                </Grid.RowDefinitions>
+                                  VerticalAlignment="Center">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="12"

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -108,7 +108,7 @@
     <x:Double x:Key="SettingsCardContentMinWidth">120</x:Double>
     <Thickness x:Key="SettingsCardHeaderIconMargin">2,0,20,0</Thickness>
     <Thickness x:Key="SettingsCardVerticalHeaderContentSpacing">0,8,0,0</Thickness>
-    <x:Double x:Key="SettingsCardWrapThreshold">460</x:Double>
+    <x:Double x:Key="SettingsCardWrapThreshold">476</x:Double>
     <x:Double x:Key="SettingsCardWrapNoIconThreshold">286</x:Double>
 
     <Style BasedOn="{StaticResource DefaultSettingsCardStyle}"

--- a/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
+++ b/labs/SettingsControls/src/SettingsCard/SettingsCard.xaml
@@ -107,7 +107,7 @@
     <x:Double x:Key="SettingsCardLeftIndention">0</x:Double>
     <x:Double x:Key="SettingsCardContentMinWidth">120</x:Double>
     <Thickness x:Key="SettingsCardHeaderIconMargin">2,0,20,0</Thickness>
-    <Thickness x:Key="SettingsCardVerticalHeaderContentSpacing">0,4,0,0</Thickness>
+    <Thickness x:Key="SettingsCardVerticalHeaderContentSpacing">0,8,0,0</Thickness>
     <x:Double x:Key="SettingsCardWrapThreshold">460</x:Double>
     <x:Double x:Key="SettingsCardWrapNoIconThreshold">286</x:Double>
 


### PR DESCRIPTION
- TextBlocks weren't announced by Narrator.
- ToggleSwitches weren't exactly vertically alignment
- Increase spacing between Header/Description and Content when in vertical mode per design spec
- Increase wrapping threshold to work better with common narrow app sizes across inbox apps