### PR TITLE
Fixed custom csproj file names

### DIFF
--- a/common/ProjectHeads/GenerateSingleSampleHeads.ps1
+++ b/common/ProjectHeads/GenerateSingleSampleHeads.ps1
@@ -85,7 +85,8 @@ $projects = [System.Collections.ArrayList]::new()
 [void]$projects.Add(".\**.*proj")
 
 # Include common dependencies required for solution to build
-[void]$projects.Add("..\..\common\CommunityToolkit.Labs.*Shared\**\*.*proj")
+[void]$projects.Add("..\..\common\CommunityToolkit.App.Shared\**\*.*proj")
+[void]$projects.Add("..\..\common\CommunityToolkit.Tests.Shared\**\*.*proj")
 [void]$projects.Add("..\..\common\CommunityToolkit.Tooling.SampleGen\*.csproj")
 [void]$projects.Add("..\..\common\CommunityToolkit.Tooling.TestGen\*.csproj")
 [void]$projects.Add("..\..\common\CommunityToolkit.Tooling.XamlNamedPropertyRelay\*.csproj")

--- a/common/ProjectHeads/SingleComponent/Tests.Uwp/ProjectTemplate.Tests.Uwp.csproj
+++ b/common/ProjectHeads/SingleComponent/Tests.Uwp/ProjectTemplate.Tests.Uwp.csproj
@@ -45,7 +45,7 @@
   <Import Project="..\..\tests\ProjectTemplate.Tests.projitems" Label="Shared" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.ProjectTemplate.csproj" />
+    <ProjectReference Include="..\..\src\*.csproj" />
   </ItemGroup>
 
   <!-- Must be imported after any shared projects in non-sdk style projects -->

--- a/common/ProjectHeads/SingleComponent/Tests.WinAppSdk/ProjectTemplate.Tests.WinAppSdk.csproj
+++ b/common/ProjectHeads/SingleComponent/Tests.WinAppSdk/ProjectTemplate.Tests.WinAppSdk.csproj
@@ -42,6 +42,6 @@
   <Import Project="..\..\tests\ProjectTemplate.Tests.projitems" Label="Shared" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.ProjectTemplate.csproj" />
+    <ProjectReference Include="..\..\src\*.csproj" />
   </ItemGroup>
 </Project>

--- a/common/ProjectHeads/SingleComponent/Uwp/ProjectTemplate.Uwp.csproj
+++ b/common/ProjectHeads/SingleComponent/Uwp/ProjectTemplate.Uwp.csproj
@@ -38,8 +38,8 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.ProjectTemplate.csproj"/>
-    <ProjectReference Include="..\..\samples\ProjectTemplate.Samples.csproj"/>
+    <ProjectReference Include="..\..\src\*.csproj"/>
+    <ProjectReference Include="..\..\samples\*.csproj"/>
   </ItemGroup>
   
   <!-- Must be imported after any shared projects in non-sdk style projects -->

--- a/common/ProjectHeads/SingleComponent/Wasm/ProjectTemplate.Wasm.csproj
+++ b/common/ProjectHeads/SingleComponent/Wasm/ProjectTemplate.Wasm.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.ProjectTemplate.csproj" />
-    <ProjectReference Include="..\..\samples\ProjectTemplate.Samples.csproj" />
+    <ProjectReference Include="..\..\src\*.csproj" />
+    <ProjectReference Include="..\..\samples\*.csproj" />
   </ItemGroup>
 </Project>

--- a/common/ProjectHeads/SingleComponent/WinAppSdk/ProjectTemplate.WinAppSdk.csproj
+++ b/common/ProjectHeads/SingleComponent/WinAppSdk/ProjectTemplate.WinAppSdk.csproj
@@ -24,8 +24,8 @@
   <Import Project="$(RepositoryDirectory)common\ProjectHeads\App.Head.WinAppSdk.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit.Labs.WinUI.ProjectTemplate.csproj" />
-    <ProjectReference Include="..\..\samples\ProjectTemplate.Samples.csproj" />
+    <ProjectReference Include="..\..\src\*.csproj" />
+    <ProjectReference Include="..\..\samples\*.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/common/ToolkitComponent.SampleProject.props
+++ b/common/ToolkitComponent.SampleProject.props
@@ -28,7 +28,7 @@
 
     <!-- Needed for Source Generators to find Markdown files -->
     <AdditionalFiles Include="**\*.md" Exclude="bin\**\*.md;obj\**\*.md" />
-    <ProjectReference Condition="Exists('$(MSBuildProjectDirectory)\..\src\CommunityToolkit.Labs.WinUI.$(ToolkitComponentName).csproj')" Include="$(MSBuildProjectDirectory)\..\src\CommunityToolkit.Labs.WinUI.$(ToolkitComponentName).csproj" />
+    <ProjectReference Include="$(MSBuildProjectDirectory)\..\src\*.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/components/RivePlayer/samples/RivePlayer.Samples.csproj
+++ b/components/RivePlayer/samples/RivePlayer.Samples.csproj
@@ -4,9 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Rive uses a custom csproj file name, so it must be imported manually. -->
-    <ProjectReference Include="$(MSBuildProjectDirectory)\..\src\CommunityToolkit.Labs.WinUI.Rive.RivePlayer.csproj" />
-
     <None Update="animated-login-screen.riv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This PR is a hotfix for #360 / #369. Rive changed their csproj name, and we had places where we assumed the name of the source project. The assumed name has been replaced with wildcards.

- [Fixed an issue where using a custom file name for the component source csproj prevented the solution from generating](https://github.com/CommunityToolkit/Labs-Windows/commit/ac7520a260894cd813fb36cce1c0e606d876f55b) 


