### PR TITLE
Fixed an issue where MSBuild wouldn't be detected on some machines

### DIFF
--- a/common/ProjectHeads/GenerateSingleSampleHeads.ps1
+++ b/common/ProjectHeads/GenerateSingleSampleHeads.ps1
@@ -29,7 +29,7 @@ Param (
     [switch]$UseDiagnostics = $false
 )
 
-if ($Env:Path.Contains("MSBuild") -eq $false) {
+if ($Env:Path.ToLower().Contains("msbuild") -eq $false) {
     Write-Host
     Write-Host -ForegroundColor Red "Please run from a command window that has MSBuild.exe on the PATH"
     Write-Host


### PR DESCRIPTION
This PR fixes an issue where using `OpenSolution.bat` would fail due to mismatch case on the MSBuild path on some machines.

Submitted by @[Avid29](https://github.com/Avid29):
![image](https://user-images.githubusercontent.com/9384894/221228427-862c276e-1b6b-4893-ad69-d6b0af2780e2.png)
