### PR TITLE
Workaround for Uno-exposed IDisposable errors in release mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -432,3 +432,6 @@ csharp_style_prefer_extended_property_pattern = true:suggestion
 
 # Require file header
 dotnet_diagnostic.IDE0073.severity = warning
+
+# Uno platform exposes IDisposable on Storyboard publicly when it should be internal. Ignore this.
+dotnet_code_quality.CA1001.excluded_type_names_with_derived_types = T:Windows.UI.Xaml.Media.Animation.Storyboard


### PR DESCRIPTION
This PR is a hotfix for all components that may use a Storyboard. Our CI treats all warnings as errors in release mode, so this has been suppressed until Uno can fix it.

From [here](https://github.com/CommunityToolkit/Labs-Windows/pull/275#issuecomment-1331113635):
> Some objects are marked as disposable for internal constraints, but it's not something we can change right away as it may be a breaking change (we'll take note to add it as such for our next major). Having to add `IDisposable` here is likely a result of some analyzer that can be disabled for Uno targets specifically.

