### PR TITLE
Fixed building in codespaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,13 +14,13 @@
         "/p:UnoSourceGeneratorUseGenerationHost=true",
         "/p:UnoSourceGeneratorUseGenerationController=false",
         "/p:UnoRemoteControlPort=443",
-        "--project=${workspaceFolder}/common/ProjectHeads/AllComponents/CommunityToolkit.Labs.Wasm/CommunityToolkit.Labs.Wasm.csproj"
+        "--project=${workspaceFolder}/common/ProjectHeads/AllComponents/Wasm/CommunityToolkit.App.Wasm.csproj"
       ],
       "presentation": {
         "group": "1",
         "order": 1
       },
-      "cwd": "${workspaceFolder}/common/ProjectHeads/AllComponents/CommunityToolkit.Labs.Wasm",
+      "cwd": "${workspaceFolder}/common/ProjectHeads/AllComponents/Wasm",
       "preLaunchTask": "generateAllSolution"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,7 @@
       "type": "PowerShell",
       "request": "launch",
       "name": "Discover samples",
-      "script": "${workspaceFolder}/common/MultiTarget/GenerateAllProjectReferences.ps1; ${workspaceFolder}/common/GenerateVSCodeLaunchConfig.ps1; ",
+      "script": "foreach ($component in Get-ChildItem -Directory -Depth 0 -Path './components/*') { ${workspaceFolder}/common/ProjectHeads/GenerateSingleSampleHeads.ps1 -ComponentPath $component } ; ${workspaceFolder}/common/GenerateVSCodeLaunchConfig.ps1; ",
       "presentation": {
         "group": "2",
         "order": 2

--- a/common/GenerateAllSolution.ps1
+++ b/common/GenerateAllSolution.ps1
@@ -25,11 +25,7 @@ Param (
     [string]$IncludeHeads = 'all',
 
     [Parameter(HelpMessage = "Add extra diagnostic output to slngen generator.")]
-    [switch]$UseDiagnostics = $false,
-
-    [Parameter(HelpMessage = "Only projects that support these targets will have references generated for use by deployable heads.")]
-    [ValidateSet("uwp", "wasdk", "wpf", "wasm", "linuxgtk", "macos", "ios", "android")]
-    [string[]] $MultiTarget = @("uwp", "wasdk", "wpf", "wasm", "linuxgtk", "macos", "ios", "android")
+    [switch]$UseDiagnostics = $false
 )
 
 # Generate required props for "All" solution.

--- a/common/GenerateAllSolution.ps1
+++ b/common/GenerateAllSolution.ps1
@@ -33,7 +33,6 @@ Param (
 )
 
 # Generate required props for "All" solution.
-& ./common/GenerateVSCodeLaunchConfig.ps1
 & ./common/MultiTarget/GenerateAllProjectReferences.ps1
 
 # Set up constant values

--- a/common/GenerateAllSolution.ps1
+++ b/common/GenerateAllSolution.ps1
@@ -25,7 +25,11 @@ Param (
     [string]$IncludeHeads = 'all',
 
     [Parameter(HelpMessage = "Add extra diagnostic output to slngen generator.")]
-    [switch]$UseDiagnostics = $false
+    [switch]$UseDiagnostics = $false,
+
+    [Parameter(HelpMessage = "Only projects that support these targets will have references generated for use by deployable heads.")]
+    [ValidateSet("uwp", "wasdk", "wpf", "wasm", "linuxgtk", "macos", "ios", "android")]
+    [string[]] $MultiTarget = @("uwp", "wasdk", "wpf", "wasm", "linuxgtk", "macos", "ios", "android")
 )
 
 # Generate required props for "All" solution.

--- a/common/GenerateAllSolution.ps1
+++ b/common/GenerateAllSolution.ps1
@@ -33,8 +33,8 @@ Param (
 )
 
 # Generate required props for "All" solution.
-& ./common/MultiTarget/GenerateAllProjectReferences.ps1
 & ./common/GenerateVSCodeLaunchConfig.ps1
+& ./common/MultiTarget/GenerateAllProjectReferences.ps1
 
 # Set up constant values
 $generatedSolutionFilePath = 'Toolkit.Labs.All.sln'

--- a/common/GenerateVSCodeLaunchConfig.ps1
+++ b/common/GenerateVSCodeLaunchConfig.ps1
@@ -20,12 +20,12 @@ function CreateVsCodeLaunchConfigJson {
       `"/p:UnoSourceGeneratorUseGenerationHost=true`",
       `"/p:UnoSourceGeneratorUseGenerationController=false`",
       `"/p:UnoRemoteControlPort=443`",
-      `"--project=`$`{workspaceFolder`}/components/$projectName/samples/$projectName.Wasm/$projectName.Wasm.csproj`"
+      `"--project=`$`{workspaceFolder`}/components/$projectName/heads/Wasm/$projectName.Wasm.csproj`"
     ],
     `"presentation`": {
       `"group`": `"2`"
     },
-    `"cwd`": `"`$`{workspaceFolder`}/components/$projectName/samples/$projectName.Wasm`"
+    `"cwd`": `"`$`{workspaceFolder`}/components/$projectName/heads/Wasm`"
   }";
 }
 
@@ -38,8 +38,10 @@ $launchConfig.configurations = @();
 $launchConfig.configurations += $originalConfigurations[0];
 $launchConfig.configurations += $originalConfigurations[1];
 
-foreach ($wasmProjectPath in Get-ChildItem -Recurse -Path "$PSScriptRoot/../*/*/samples/*.Wasm/*.Wasm.csproj") {
-  $projectName = [System.IO.Path]::GetFileNameWithoutExtension($wasmProjectPath) -Replace ".Wasm", "";
+& $PSScriptRoot/MultiTarget/GenerateAllProjectReferences.ps1 -MultiTarget 'wasm'
+
+foreach ($projectPath in Get-ChildItem -Directory -Depth 0 -Path "$PSScriptRoot/../components/*") {
+  $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectPath);
   Write-Host "Generating VSCode launch config for $projectName";
 
   $configJson = CreateVsCodeLaunchConfigJson $projectName;

--- a/common/MultiTarget/GenerateAllProjectReferences.ps1
+++ b/common/MultiTarget/GenerateAllProjectReferences.ps1
@@ -1,6 +1,9 @@
 Param (
   [Parameter(HelpMessage = "The directory where props files for discovered projects should be saved.")]
-  [string]$projectPropsOutputDir = "$PSScriptRoot/Generated"
+  [string]$projectPropsOutputDir = "$PSScriptRoot/Generated",
+
+  [Parameter(HelpMessage = "Only projects that support these targets will have references generated for use by deployable heads.")]
+  [string[]] $MultiTarget = @("uwp", "wasdk", "wpf", "wasm", "linuxgtk", "macos", "ios", "android")
 )
 
 $preWorkingDir = $pwd;
@@ -12,35 +15,18 @@ New-Item -ItemType Directory -Force -Path $projectPropsOutputDir -ErrorAction Si
 
 # Discover projects in provided paths
 foreach ($projectPath in Get-ChildItem -Directory -Depth 0 -Path "$PSScriptRoot/../../components/*") {
-  # Normalize project path
-  $projectName = $projectPath.Name;
-
-  # Folder layout is expected to match the Community Toolkit.
-  # Uses the <MultiTarget> values from the source library project as the fallback for the sample project.
-  # This behavior also implemented in MultiTarget.props for TargetFramework evaluation. 
   $srcPath = Resolve-Path "$($projectPath.FullName)\src";
   $srcProjectPath = Get-ChildItem -File "$srcPath\*.csproj";
 
   $samplePath = Resolve-Path "$($projectPath.FullName)\samples";
   $sampleProjectPath = Get-ChildItem -File "$samplePath\*.csproj";
 
-  if ($srcProjectPath.Length -eq 0) {
-    Write-Error "Could not locate source csproj for $projectName";
-    exit(-1);
-  }
-
-  if ($sampleProjectPath.Length -eq 0) {
-    Write-Error "Could not locate sample csproj for $projectName";
-    exit(-1);
-  }
-
   # Generate <ProjectReference>s for sample project
   # Use source project MultiTarget as first fallback.
-  & $PSScriptRoot\GenerateMultiTargetAwareProjectReferenceProps.ps1 -projectPath $sampleProjectPath -outputPath "$projectPropsOutputDir/$($sampleProjectPath.BaseName).props" -multiTargetFallbackPropsPath @("$srcPath/MultiTarget.props", "$samplePath/MultiTarget.props", "$PSScriptRoot/Defaults.props");
+  & $PSScriptRoot\GenerateMultiTargetAwareProjectReferenceProps.ps1 -projectPath $sampleProjectPath -outputPath "$projectPropsOutputDir/$($sampleProjectPath.BaseName).props" -MultiTarget $MultiTarget
 
   # Generate <ProjectReference>s for src project
-  & $PSScriptRoot\GenerateMultiTargetAwareProjectReferenceProps.ps1 -projectPath $srcProjectPath -outputPath "$projectPropsOutputDir/$($srcProjectPath.BaseName).props" -multiTargetFallbackPropsPath @("$srcPath/MultiTarget.props", "$PSScriptRoot/Defaults.props");
+  & $PSScriptRoot\GenerateMultiTargetAwareProjectReferenceProps.ps1 -projectPath $srcProjectPath -outputPath "$projectPropsOutputDir/$($srcProjectPath.BaseName).props" -MultiTarget $MultiTarget
 }
-
 
 Set-Location $preWorkingDir;

--- a/common/MultiTarget/GenerateMultiTargetAwareProjectReferenceProps.ps1
+++ b/common/MultiTarget/GenerateMultiTargetAwareProjectReferenceProps.ps1
@@ -5,7 +5,7 @@ Param (
     [Parameter(HelpMessage = "A path to a .props file where generated content should be saved to.", Mandatory = $true)] 
     [string]$outputPath,
 
-    [Parameter(HelpMessage = "The path to the template used to generate the props file.")] 
+    [Parameter(HelpMessage = "The path to the template used to generate the props file.")]
     [string]$templatePath = "$PSScriptRoot/MultiTargetAwareProjectReference.props.template",
 
     [Parameter(HelpMessage = "The path to the props file that contains the default MultiTarget values.")] 
@@ -15,7 +15,11 @@ Param (
     [string]$projectFileNamePlaceholder = "[ProjectFileName]",
 
     [Parameter(HelpMessage = "The placeholder text to replace when inserting the project path into the template.")] 
-    [string]$projectRootPlaceholder = "[ProjectRoot]"
+    [string]$projectRootPlaceholder = "[ProjectRoot]",
+
+    [Parameter(HelpMessage = "Only projects that support these targets will have references generated for use by deployable heads.")]
+    [ValidateSet("uwp", "wasdk", "wpf", "wasm", "linuxgtk", "macos", "ios", "android")]
+    [string[]] $MultiTarget = @("uwp", "wasdk", "wpf", "wasm", "linuxgtk", "macos", "ios", "android")
 )
 
 $preWorkingDir = $pwd;
@@ -29,56 +33,31 @@ Set-Location $preWorkingDir;
 # Insert csproj file name.
 $csprojFileName = [System.IO.Path]::GetFileName($relativeProjectPath);
 $templateContents = $templateContents -replace [regex]::escape($projectFileNamePlaceholder), $csprojFileName;
+$projectName = (Get-Item (Split-Path -Parent $projectPath)).Name;
 
 # Insert project directory
 $projectDirectoryRelativeToRoot = [System.IO.Path]::GetDirectoryName($relativeProjectPath).TrimStart('.').TrimStart('\');
 $templateContents = $templateContents -replace [regex]::escape($projectRootPlaceholder), "$projectDirectoryRelativeToRoot";
 
-function LoadMultiTargetsFrom([string] $path) {
-    $fileContents = "";
+# Load multitarget preferences for project
+$multiTargets = & $PSScriptRoot\GetMultiTargets.ps1 -ComponentName $projectName -ErrorAction Stop;
+    
+$templateContents = $templateContents -replace [regex]::escape("[IntendedTargets]"), $multiTargets;
+$multiTargets = $multiTargets.Split(';');
 
-    # If file does not exist
-    if ($false -eq (Test-Path -Path $path -PathType Leaf)) {
-        # Load first available default
-        foreach ($fallbackPath in $multiTargetFallbackPropsPath) {
-            if (Test-Path $fallbackPath) {
-                $fileContents = Get-Content $fallbackPath -ErrorAction Stop;
-                break;
-            }
-        }
-    }
-    else {
-        # Load requested file
-        $fileContents = Get-Content $path -ErrorAction Stop;
-    }
-
-    # Parse file contents
-    $regex = Select-String -Pattern '<MultiTarget>(.+?)<\/MultiTarget>' -InputObject $fileContents;
-
-    if ($null -eq $regex -or $null -eq $regex.Matches -or $null -eq $regex.Matches.Groups -or $regex.Matches.Groups.Length -lt 2) {
-        Write-Error "Couldn't get MultiTarget property from $path";
-        exit(-1);
-    }
-
-    return $regex.Matches.Groups[1].Value;
+function ShouldMultiTarget([string] $target) {
+    return ($multiTargets.Contains($target) -and $MultiTarget.Contains($target)).ToString().ToLower()
 }
 
-# Load multitarget preferences for project
-$multiTargets = LoadMultiTargetsFrom("$([System.IO.Path]::GetDirectoryName($projectPath))\MultiTarget.props");
-
-$templateContents = $templateContents -replace [regex]::escape("[IntendedTargets]"), $multiTargets;
-
-$multiTargets = $multiTargets.Split(';');
 Write-Host "Generating project references for $([System.IO.Path]::GetFileNameWithoutExtension($csprojFileName)): $($multiTargets -Join ', ')"
-
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetWasm]"), "'$($multiTargets.Contains("wasm").ToString().ToLower())'";
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetUwp]"), "'$($multiTargets.Contains("uwp").ToString().ToLower())'";
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetWasdk]"), "'$($multiTargets.Contains("wasdk").ToString().ToLower())'";
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetWpf]"), "'$($multiTargets.Contains("wpf").ToString().ToLower())'";
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetLinuxGtk]"), "'$($multiTargets.Contains("linuxgtk").ToString().ToLower())'";
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetMacOS]"), "'$($multiTargets.Contains("macos").ToString().ToLower())'";
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetiOS]"), "'$($multiTargets.Contains("ios").ToString().ToLower())'";
-$templateContents = $templateContents -replace [regex]::escape("[CanTargetDroid]"), "'$($multiTargets.Contains("android").ToString().ToLower())'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetWasm]"), "'$(ShouldMultiTarget "wasm")'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetUwp]"), "'$(ShouldMultiTarget "uwp")'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetWasdk]"), "'$(ShouldMultiTarget "wasdk")'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetWpf]"), "'$(ShouldMultiTarget "wpf")'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetLinuxGtk]"), "'$(ShouldMultiTarget "linuxgtk")'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetMacOS]"), "'$(ShouldMultiTarget "macos")'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetiOS]"), "'$(ShouldMultiTarget "ios")'";
+$templateContents = $templateContents -replace [regex]::escape("[CanTargetDroid]"), "'$(ShouldMultiTarget "droid")'";
 
 # Save to disk
 Set-Content -Path $outputPath -Value $templateContents;

--- a/common/MultiTarget/GetMultiTargets.ps1
+++ b/common/MultiTarget/GetMultiTargets.ps1
@@ -1,0 +1,58 @@
+<#
+.SYNOPSIS
+    Returns the defined MultiTarget value for the provided project name.
+.DESCRIPTION
+    Locates a component by the provided name from the root ./components folder, and pulls the <MultiTarget> value that should be used.
+    The MultiTarget value can be defined by a component in multiple places, but in a MultiTarget.props next to a *.csproj.
+    
+    The load order is as follows:
+    - ./components/SomeComponent/src/MultiTarget.props
+    - ./components/SomeComponent/samples/MultiTarget.props
+    - $PSScriptRoot/Defaults.props
+.PARAMETER ComponentName
+    The name of the component.
+.EXAMPLE
+    C:\PS> .\GetMultiTargets "CanvasView"
+    Return the multitargets for the component named "CanvasView".
+.NOTES
+    Author: Windows Community Toolkit Labs Team
+    Date:   February 27, 2023
+#>
+Param (    
+    [Parameter(HelpMessage = "The name of the component.", Mandatory = $true)] 
+    [string]$ComponentName
+)
+
+$componentPath = "$PSScriptRoot/../../components/$ComponentName";
+
+Test-Path $componentPath -ErrorAction Stop | Out-Null
+
+# Folder layout is expected to match the Community Toolkit.
+# Uses the <MultiTarget> values from the source library project as the fallback for the sample project.
+# This behavior also implemented in MultiTarget.props for TargetFramework evaluation. 
+$parent = Split-Path -Parent $projectPath
+$srcPath = Resolve-Path "$parent\..\src";
+$samplePath = Resolve-Path "$parent\..\samples";
+
+$multiTargetFallbackPropsPaths = @("$srcPath/MultiTarget.props", "$samplePath/MultiTarget.props", "$PSScriptRoot/Defaults.props")
+
+$fileContents = "";
+# Load first available default
+foreach ($fallbackPath in $multiTargetFallbackPropsPaths) {
+    if (Test-Path $fallbackPath) {
+        $fileContents = Get-Content $fallbackPath -ErrorAction Stop;
+        break;
+    }
+}
+
+# Parse file contents
+$regex = Select-String -Pattern '<MultiTarget>(.+?)<\/MultiTarget>' -InputObject $fileContents;
+
+if ($null -eq $regex -or $null -eq $regex.Matches -or $null -eq $regex.Matches.Groups -or $regex.Matches.Groups.Length -lt 2) {
+    Write-Error "Couldn't get MultiTarget property from $path";
+    exit(-1);
+}
+
+$value = $regex.Matches.Groups[1].Value;
+
+return $value;

--- a/common/ProjectHeads/GenerateSingleSampleHeads.ps1
+++ b/common/ProjectHeads/GenerateSingleSampleHeads.ps1
@@ -29,7 +29,7 @@ Param (
     [switch]$UseDiagnostics = $false
 )
 
-if ($Env:Path.ToLower().Contains("msbuild") -eq $false) {
+if ($null -ne $Env:Path -and $Env:Path.ToLower().Contains("msbuild") -eq $false) {
     Write-Host
     Write-Host -ForegroundColor Red "Please run from a command window that has MSBuild.exe on the PATH"
     Write-Host


### PR DESCRIPTION
In #360 and #369, we organized and consolidated our projects heads, and renamed the folder which components are contained in.

While these were tested to work locally, Codespaces was not reconfigured to use the new paths.

This PR
- Fixes sample discovery in codespaces.
- Fixes head generation in codespaces.
- Fixes building and deploying in codespaces.
- Fixed an issue where a missing `Path` environment variable would cause the build to fail (e.g., on linux)