### PR TITLE
Renamed the "All component" solution

### DIFF
--- a/.devcontainer/default.code-workspace
+++ b/.devcontainer/default.code-workspace
@@ -5,7 +5,7 @@
 		}
 	],
 	"settings": {
-		"omnisharp.defaultLaunchSolution": "Toolkit.Labs.All.sln",
+		"omnisharp.defaultLaunchSolution": "CommunityToolkit.AllComponents.sln",
 		"omnisharp.disableMSBuildDiagnosticWarning": true,
 		"omnisharp.enableRoslynAnalyzers": true,
 		"omnisharp.useGlobalMono": "never",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ matrix.platform == 'WinUI3' }}
 
       - name: MSBuild
-        run: msbuild.exe Toolkit.Labs.All.sln /restore /nowarn:MSB4011 -p:Configuration=Release
+        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release
 
       # Build All Packages
       - name: pack experiments

--- a/.gitignore
+++ b/.gitignore
@@ -356,7 +356,7 @@ MigrationBackup/
 .idea/
 
 # Community Toolkit Labs generated files
-Toolkit.Labs.All.sln
+CommunityToolkit.AllComponents.sln
 common/MultiTarget/Generated/**
 heads/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "omnisharp.defaultLaunchSolution": "Toolkit.Labs.All.sln",
+    "omnisharp.defaultLaunchSolution": "CommunityToolkit.AllComponents.sln",
     "omnisharp.disableMSBuildDiagnosticWarning": true,
     "omnisharp.enableRoslynAnalyzers": true,
     "omnisharp.useGlobalMono": "never",

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -68,7 +68,7 @@ Open up an issue on the main Toolkit repo using the `Toolkit Labs Transfer` Issu
 
 ## Building the Sample App
 
-You can build the main Sample App solution to see all the experiments currently available in this repository by running the `GenerateAllSolution.bat` script in the repo root. Then just open the `Toolkit.Labs.All.sln` solution in Visual Studio. You can run one of the project heads such as `CommunityToolkit.App.WinAppSdk` to run the sample app for that platform.
+You can build the main Sample App solution to see all the experiments currently available in this repository by running the `GenerateAllSolution.bat` script in the repo root. Then just open the `CommunityToolkit.AllComponents.sln` solution in Visual Studio. You can run one of the project heads such as `CommunityToolkit.App.WinAppSdk` to run the sample app for that platform.
 
 If you'd like to run a head beyond UWP, Wasm, or the WinAppSDK, you'll need to run the `UseTargetFrameworks.ps1` script first in the `common/Scripts` directory. e.g. `.\UseTargetFrameworks.ps1 -targets all`
 

--- a/common/CommunityToolkit.App.Shared/AppLoadingView.xaml.cs
+++ b/common/CommunityToolkit.App.Shared/AppLoadingView.xaml.cs
@@ -85,7 +85,7 @@ public sealed partial class AppLoadingView : Page
             return;
         }
 
-#if LABS_ALL_SAMPLES
+#if ALL_SAMPLES
         ScheduleNavigate(typeof(Shell), sampleDocs);
 #else
         var samples = FindReferencedSamples().ToArray();

--- a/common/GenerateAllSolution.ps1
+++ b/common/GenerateAllSolution.ps1
@@ -32,7 +32,7 @@ Param (
 & ./common/MultiTarget/GenerateAllProjectReferences.ps1
 
 # Set up constant values
-$generatedSolutionFilePath = 'Toolkit.Labs.All.sln'
+$generatedSolutionFilePath = 'CommunityToolkit.AllComponents.sln'
 $platforms = '"Any CPU;x64;x86;ARM64"'
 $slngenConfig = "--folders true --collapsefolders true --ignoreMainProject"
 

--- a/common/ProjectHeads/App.Head.props
+++ b/common/ProjectHeads/App.Head.props
@@ -28,7 +28,7 @@
     <IsProjectTemplateHead Condition="$(MSBuildProjectName.StartsWith('ProjectTemplate')) == 'true'">true</IsProjectTemplateHead>
     <IsSingleExperimentHead Condition="'$(IsAllExperimentHead)' != 'true' AND '$(IsProjectTemplateHead)' != 'true'">true</IsSingleExperimentHead>
 
-    <DefineConstants Condition="$(IsAllExperimentHead) == 'true'">$(DefineConstants);LABS_ALL_SAMPLES</DefineConstants>
+    <DefineConstants Condition="$(IsAllExperimentHead) == 'true'">$(DefineConstants);ALL_SAMPLES</DefineConstants>
 
     <SlnGenIsDeployable>true</SlnGenIsDeployable>
   </PropertyGroup>


### PR DESCRIPTION
This PR
- Renames `Toolkit.Labs.All.sln` to `CommunityToolkit.AllComponents.sln`
- Closes #399 
- Has been tested locally and works as expected
- Renames `LABS_ALL_SAMPLES` to `ALL_SAMPLES`.