### PR TITLE
Fixed SettingsCard not lost force when touch leave

### DIFF
--- a/components/SettingsControls/src/SettingsCard/SettingsCard.cs
+++ b/components/SettingsControls/src/SettingsCard/SettingsCard.cs
@@ -66,6 +66,8 @@ public partial class SettingsCard : ButtonBase
 
         PointerEntered += Control_PointerEntered;
         PointerExited += Control_PointerExited;
+        PointerCaptureLost += Control_PointerCaptureLost;
+        PointerCanceled += Control_PointerCanceled;
         PreviewKeyDown += Control_PreviewKeyDown;
         PreviewKeyUp += Control_PreviewKeyUp;
     }
@@ -74,6 +76,8 @@ public partial class SettingsCard : ButtonBase
     {
         PointerEntered -= Control_PointerEntered;
         PointerExited -= Control_PointerExited;
+        PointerCaptureLost -= Control_PointerCaptureLost;
+        PointerCanceled -= Control_PointerCanceled;
         PreviewKeyDown -= Control_PreviewKeyDown;
         PreviewKeyUp -= Control_PreviewKeyUp;
     }
@@ -94,16 +98,30 @@ public partial class SettingsCard : ButtonBase
         }
     }
 
-    public void Control_PointerExited(object sender, PointerRoutedEventArgs e)
-    {
-        base.OnPointerExited(e);
-        VisualStateManager.GoToState(this, NormalState, true);
-    }
     public void Control_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
         base.OnPointerEntered(e);
         VisualStateManager.GoToState(this, PointerOverState, true);
     }
+    
+    public void Control_PointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        base.OnPointerExited(e);
+        VisualStateManager.GoToState(this, NormalState, true);
+    }
+    
+    private void Control_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        VisualStateManager.GoToState(this, NormalState, true);
+    }
+
+    private void Control_PointerCanceled(object sender, PointerRoutedEventArgs e)
+    {
+        base.OnPointerCanceled(e);
+        VisualStateManager.GoToState(this, NormalState, true);
+    }
+
     protected override void OnPointerPressed(PointerRoutedEventArgs e)
     {
         //  e.Handled = true;
@@ -113,6 +131,7 @@ public partial class SettingsCard : ButtonBase
             VisualStateManager.GoToState(this, PressedState, true);
         }
     }
+    
     protected override void OnPointerReleased(PointerRoutedEventArgs e)
     {
         if (IsClickEnabled)


### PR DESCRIPTION
As the video shows. When touch leave, the force not lost.

https://user-images.githubusercontent.com/27689196/226120642-dc3730e5-3f6c-4c36-8a5d-b279fc4b0eb3.mp4

It becuse the `PointerCaptureLost` event not be processed. So I add the `Control_PointerCaptureLost` to fix it.

https://user-images.githubusercontent.com/27689196/226121692-620c468b-0d13-4e4d-9d9c-484886087a0c.mp4

If this is a feature, just ignore this pr.