### PR TITLE
Update submodule with fixes, fixed SettingsExpander sample crash

### DIFF
--- a/components/SettingsControls/samples/SettingsExpanderSample.xaml
+++ b/components/SettingsControls/samples/SettingsExpanderSample.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsExpanderSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,69 +7,70 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
 
-    <labs:SettingsExpander x:Name="settingsCard"
-                           Description="The SettingsExpander has the same properties as a Card, and you can set SettingsCard as part of the Items collection."
-                           Header="SettingsExpander"
-                           IsExpanded="{x:Bind IsCardExpanded, Mode=OneWay}">
-        <!--  TODO: This should be TwoWay bound but throws compile error in Uno.  -->
-        <labs:SettingsExpander.HeaderIcon>
-            <FontIcon Glyph="&#xE91B;" />
-        </labs:SettingsExpander.HeaderIcon>
-        <ComboBox SelectedIndex="0">
-            <ComboBoxItem>Option 1</ComboBoxItem>
-            <ComboBoxItem>Option 2</ComboBoxItem>
-            <ComboBoxItem>Option 3</ComboBoxItem>
-        </ComboBox>
+	<labs:SettingsExpander x:Name="settingsCard"
+	                       Description="The SettingsExpander has the same properties as a Card, and you can set SettingsCard as part of the Items collection."
+	                       Header="SettingsExpander"
+	                       IsEnabled="{x:Bind IsCardEnabled, Mode=OneWay}"
+	                       IsExpanded="{x:Bind IsCardExpanded, Mode=OneWay}">
+		<!--  TODO: This should be TwoWay bound but throws compile error in Uno.  -->
+		<labs:SettingsExpander.HeaderIcon>
+			<FontIcon Glyph="&#xE91B;" />
+		</labs:SettingsExpander.HeaderIcon>
+		<ComboBox SelectedIndex="0">
+			<ComboBoxItem>Option 1</ComboBoxItem>
+			<ComboBoxItem>Option 2</ComboBoxItem>
+			<ComboBoxItem>Option 3</ComboBoxItem>
+		</ComboBox>
 
-        <labs:SettingsExpander.Items>
-            <labs:SettingsCard Header="A basic SettingsCard within an SettingsExpander">
-                <Button Content="Button" />
-            </labs:SettingsCard>
-            <labs:SettingsCard Description="SettingsCard within an Expander can be made clickable too!"
-                               Header="This item can be clicked"
-                               IsClickEnabled="True" />
+		<labs:SettingsExpander.Items>
+			<labs:SettingsCard Header="A basic SettingsCard within an SettingsExpander">
+				<Button Content="Button" />
+			</labs:SettingsCard>
+			<labs:SettingsCard Description="SettingsCard within an Expander can be made clickable too!"
+			                   Header="This item can be clicked"
+			                   IsClickEnabled="True" />
 
-            <labs:SettingsCard ContentAlignment="Left">
-                <CheckBox Content="Here the ContentAlignment is set to Left. This is great for e.g. CheckBoxes or RadioButtons." />
-            </labs:SettingsCard>
+			<labs:SettingsCard ContentAlignment="Left">
+				<CheckBox Content="Here the ContentAlignment is set to Left. This is great for e.g. CheckBoxes or RadioButtons." />
+			</labs:SettingsCard>
 
-            <labs:SettingsCard HorizontalContentAlignment="Left"
-                               ContentAlignment="Vertical"
-                               Description="You can also align your content vertically. Make sure to set the HorizontalAlignment to Left when you do!"
-                               Header="Vertically aligned">
-                <GridView SelectedIndex="1">
-                    <GridViewItem>
-                        <Border Width="64"
-                                Height="64"
-                                Background="#0078D4"
-                                CornerRadius="4" />
-                    </GridViewItem>
-                    <GridViewItem>
-                        <Border Width="64"
-                                Height="64"
-                                Background="#005EB7"
-                                CornerRadius="4" />
-                    </GridViewItem>
-                    <GridViewItem>
-                        <Border Width="64"
-                                Height="64"
-                                Background="#003D92"
-                                CornerRadius="4" />
-                    </GridViewItem>
-                    <GridViewItem>
-                        <Border Width="64"
-                                Height="64"
-                                Background="#001968"
-                                CornerRadius="4" />
-                    </GridViewItem>
-                </GridView>
-            </labs:SettingsCard>
-            <labs:SettingsCard Description="You can override the Left indention of a SettingsCard by overriding the SettingsCardLeftIndention"
-                               Header="Customization">
-                <labs:SettingsCard.Resources>
-                    <x:Double x:Key="SettingsCardLeftIndention">40</x:Double>
-                </labs:SettingsCard.Resources>
-            </labs:SettingsCard>
-        </labs:SettingsExpander.Items>
-    </labs:SettingsExpander>
+			<labs:SettingsCard HorizontalContentAlignment="Left"
+			                   ContentAlignment="Vertical"
+			                   Description="You can also align your content vertically. Make sure to set the HorizontalAlignment to Left when you do!"
+			                   Header="Vertically aligned">
+				<GridView SelectedIndex="1">
+					<GridViewItem>
+						<Border Width="64"
+						        Height="64"
+						        Background="#0078D4"
+						        CornerRadius="4" />
+					</GridViewItem>
+					<GridViewItem>
+						<Border Width="64"
+						        Height="64"
+						        Background="#005EB7"
+						        CornerRadius="4" />
+					</GridViewItem>
+					<GridViewItem>
+						<Border Width="64"
+						        Height="64"
+						        Background="#003D92"
+						        CornerRadius="4" />
+					</GridViewItem>
+					<GridViewItem>
+						<Border Width="64"
+						        Height="64"
+						        Background="#001968"
+						        CornerRadius="4" />
+					</GridViewItem>
+				</GridView>
+			</labs:SettingsCard>
+			<labs:SettingsCard Description="You can override the Left indention of a SettingsCard by overriding the SettingsCardLeftIndention"
+			                   Header="Customization">
+				<labs:SettingsCard.Resources>
+					<x:Double x:Key="SettingsCardLeftIndention">40</x:Double>
+				</labs:SettingsCard.Resources>
+			</labs:SettingsCard>
+		</labs:SettingsExpander.Items>
+	</labs:SettingsExpander>
 </Page>

--- a/components/SettingsControls/samples/SettingsExpanderSample.xaml
+++ b/components/SettingsControls/samples/SettingsExpanderSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsExpanderSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,70 +7,70 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
 
-	<labs:SettingsExpander x:Name="settingsCard"
-	                       Description="The SettingsExpander has the same properties as a Card, and you can set SettingsCard as part of the Items collection."
-	                       Header="SettingsExpander"
-	                       IsEnabled="{x:Bind IsCardEnabled, Mode=OneWay}"
-	                       IsExpanded="{x:Bind IsCardExpanded, Mode=OneWay}">
-		<!--  TODO: This should be TwoWay bound but throws compile error in Uno.  -->
-		<labs:SettingsExpander.HeaderIcon>
-			<FontIcon Glyph="&#xE91B;" />
-		</labs:SettingsExpander.HeaderIcon>
-		<ComboBox SelectedIndex="0">
-			<ComboBoxItem>Option 1</ComboBoxItem>
-			<ComboBoxItem>Option 2</ComboBoxItem>
-			<ComboBoxItem>Option 3</ComboBoxItem>
-		</ComboBox>
+    <labs:SettingsExpander x:Name="settingsCard"
+                           Description="The SettingsExpander has the same properties as a Card, and you can set SettingsCard as part of the Items collection."
+                           Header="SettingsExpander"
+                           IsEnabled="{x:Bind IsCardEnabled, Mode=OneWay}"
+                           IsExpanded="{x:Bind IsCardExpanded, Mode=OneWay}">
+        <!--  TODO: This should be TwoWay bound but throws compile error in Uno.  -->
+        <labs:SettingsExpander.HeaderIcon>
+            <FontIcon Glyph="&#xE91B;" />
+        </labs:SettingsExpander.HeaderIcon>
+        <ComboBox SelectedIndex="0">
+            <ComboBoxItem>Option 1</ComboBoxItem>
+            <ComboBoxItem>Option 2</ComboBoxItem>
+            <ComboBoxItem>Option 3</ComboBoxItem>
+        </ComboBox>
 
-		<labs:SettingsExpander.Items>
-			<labs:SettingsCard Header="A basic SettingsCard within an SettingsExpander">
-				<Button Content="Button" />
-			</labs:SettingsCard>
-			<labs:SettingsCard Description="SettingsCard within an Expander can be made clickable too!"
-			                   Header="This item can be clicked"
-			                   IsClickEnabled="True" />
+        <labs:SettingsExpander.Items>
+            <labs:SettingsCard Header="A basic SettingsCard within an SettingsExpander">
+                <Button Content="Button" />
+            </labs:SettingsCard>
+            <labs:SettingsCard Description="SettingsCard within an Expander can be made clickable too!"
+                               Header="This item can be clicked"
+                               IsClickEnabled="True" />
 
-			<labs:SettingsCard ContentAlignment="Left">
-				<CheckBox Content="Here the ContentAlignment is set to Left. This is great for e.g. CheckBoxes or RadioButtons." />
-			</labs:SettingsCard>
+            <labs:SettingsCard ContentAlignment="Left">
+                <CheckBox Content="Here the ContentAlignment is set to Left. This is great for e.g. CheckBoxes or RadioButtons." />
+            </labs:SettingsCard>
 
-			<labs:SettingsCard HorizontalContentAlignment="Left"
-			                   ContentAlignment="Vertical"
-			                   Description="You can also align your content vertically. Make sure to set the HorizontalAlignment to Left when you do!"
-			                   Header="Vertically aligned">
-				<GridView SelectedIndex="1">
-					<GridViewItem>
-						<Border Width="64"
-						        Height="64"
-						        Background="#0078D4"
-						        CornerRadius="4" />
-					</GridViewItem>
-					<GridViewItem>
-						<Border Width="64"
-						        Height="64"
-						        Background="#005EB7"
-						        CornerRadius="4" />
-					</GridViewItem>
-					<GridViewItem>
-						<Border Width="64"
-						        Height="64"
-						        Background="#003D92"
-						        CornerRadius="4" />
-					</GridViewItem>
-					<GridViewItem>
-						<Border Width="64"
-						        Height="64"
-						        Background="#001968"
-						        CornerRadius="4" />
-					</GridViewItem>
-				</GridView>
-			</labs:SettingsCard>
-			<labs:SettingsCard Description="You can override the Left indention of a SettingsCard by overriding the SettingsCardLeftIndention"
-			                   Header="Customization">
-				<labs:SettingsCard.Resources>
-					<x:Double x:Key="SettingsCardLeftIndention">40</x:Double>
-				</labs:SettingsCard.Resources>
-			</labs:SettingsCard>
-		</labs:SettingsExpander.Items>
-	</labs:SettingsExpander>
+            <labs:SettingsCard HorizontalContentAlignment="Left"
+                               ContentAlignment="Vertical"
+                               Description="You can also align your content vertically. Make sure to set the HorizontalAlignment to Left when you do!"
+                               Header="Vertically aligned">
+                <GridView SelectedIndex="1">
+                    <GridViewItem>
+                        <Border Width="64"
+                                Height="64"
+                                Background="#0078D4"
+                                CornerRadius="4" />
+                    </GridViewItem>
+                    <GridViewItem>
+                        <Border Width="64"
+                                Height="64"
+                                Background="#005EB7"
+                                CornerRadius="4" />
+                    </GridViewItem>
+                    <GridViewItem>
+                        <Border Width="64"
+                                Height="64"
+                                Background="#003D92"
+                                CornerRadius="4" />
+                    </GridViewItem>
+                    <GridViewItem>
+                        <Border Width="64"
+                                Height="64"
+                                Background="#001968"
+                                CornerRadius="4" />
+                    </GridViewItem>
+                </GridView>
+            </labs:SettingsCard>
+            <labs:SettingsCard Description="You can override the Left indention of a SettingsCard by overriding the SettingsCardLeftIndention"
+                               Header="Customization">
+                <labs:SettingsCard.Resources>
+                    <x:Double x:Key="SettingsCardLeftIndention">40</x:Double>
+                </labs:SettingsCard.Resources>
+            </labs:SettingsCard>
+        </labs:SettingsExpander.Items>
+    </labs:SettingsExpander>
 </Page>

--- a/components/SettingsControls/samples/SettingsExpanderSample.xaml.cs
+++ b/components/SettingsControls/samples/SettingsExpanderSample.xaml.cs
@@ -5,8 +5,7 @@
 namespace SettingsControlsExperiment.Samples;
 
 [ToolkitSampleBoolOption("IsCardExpanded", false, Title = "Is Expanded")]
-// [ToolkitSampleBoolOption("IsCardEnabled", true, Title = "Is Enabled")] Disabled for now, see: https://github.com/CommunityToolkit/Labs-Windows/issues/362
-
+[ToolkitSampleBoolOption("IsCardEnabled", true, Title = "Is Enabled")]
 [ToolkitSample(id: nameof(SettingsExpanderSample), "SettingsExpander", description: "The SettingsExpander can be used to group settings. SettingsCards can be customized in terms of alignment and content.")]
 public sealed partial class SettingsExpanderSample : Page
 {

--- a/components/StackedNotificationsBehavior/samples/StackedNotificationsBehavior.md
+++ b/components/StackedNotificationsBehavior/samples/StackedNotificationsBehavior.md
@@ -5,8 +5,8 @@ description: A behavior to add stacked notifications to a WinUI InfoBar control.
 keywords: StackedNotificationsBehavior, Control, Layout, InfoBar, Behavior
 dev_langs:
   - csharp
-category: Behaviors
-subcategory: StatusAndInfo
+category: Xaml
+subcategory: Behaviors
 discussion-id: 312
 issue-id: 210
 ---


### PR DESCRIPTION
This PR
- Incorporates the fixes from https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/37 
- Re-enables the generated IsCardEnabled boolean property in the SettingsExpanderSample 