### PR TITLE
[Segmented] Improvements to EqualPanel

### DIFF
--- a/components/SegmentedControl/src/CommunityToolkit.Labs.WinUI.SegmentedControl.csproj
+++ b/components/SegmentedControl/src/CommunityToolkit.Labs.WinUI.SegmentedControl.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ToolkitComponentName>SegmentedControl</ToolkitComponentName>
     <Description>This package contains SegmentedControl.</Description>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.Labs.WinUI.SegmentedControlRns</RootNamespace>

--- a/components/SegmentedControl/src/EqualPanel.cs
+++ b/components/SegmentedControl/src/EqualPanel.cs
@@ -37,18 +37,27 @@ public partial class EqualPanel : Panel
 
         if (Children.Count > 0)
         {
-            SetMaxDimensions(Children, availableSize);
-
-            // Equal columns based on the available width
-            if (HorizontalAlignment == HorizontalAlignment.Stretch)
+            foreach (var child in Children)
             {
-                // Adjust for spacing
+                child.Measure(availableSize);
+                
+                maxItemWidth = Math.Max(maxItemWidth, child.DesiredSize.Width);
+                maxItemHeight = Math.Max(maxItemHeight, child.DesiredSize.Height);
+            }
+
+            // Return equal widths based on the widest item
+            // In very specific edge cases the AvailableWidth might be infinite resulting in a crash.
+            if (HorizontalAlignment != HorizontalAlignment.Stretch || double.IsInfinity(availableSize.Width))
+            {
+                return new Size((maxItemWidth * Children.Count) + (Spacing * (Children.Count - 1)), maxItemHeight);
+            }
+            else
+            {
+                // Equal columns based on the available width, adjust for spacing
                 double totalWidth = availableSize.Width - (Spacing * (Children.Count - 1));
                 maxItemWidth = totalWidth / Children.Count;
                 return new Size(availableSize.Width, maxItemHeight);
             }
-            // Else, return equal widths based on the widest item
-            return new Size((maxItemWidth * Children.Count) + (Spacing * (Children.Count - 1)), maxItemHeight);
         }
         else
         {
@@ -59,31 +68,20 @@ public partial class EqualPanel : Panel
     protected override Size ArrangeOverride(Size finalSize)
     {
         var x = 0.0;
+
         foreach (var child in Children)
         {
             child.Arrange(new Rect(x, 0, maxItemWidth, maxItemHeight));
             x += maxItemWidth + Spacing;
         }
-        return finalSize;
-    }
-
-    private void SetMaxDimensions(UIElementCollection items, Size availableSize)
-    {
-        foreach (var item in items)
+        System.Diagnostics.Debug.WriteLine("Actual: " + x + "  -  Final: " + finalSize.Width);
+        if (finalSize.Width > x)
         {
-            item.Measure(availableSize);
-            double desiredWidth = item.DesiredSize.Width;
-            if (desiredWidth > maxItemWidth)
-            {
-                maxItemWidth = desiredWidth;
-            }
-
-            double desiredHeight = item.DesiredSize.Height;
-            if (desiredHeight > maxItemHeight)
-            {
-                maxItemHeight = desiredHeight;
-            }
+            MeasureOverride(finalSize);
         }
+
+      
+        return finalSize;
     }
     private void OnHorizontalAlignmentChanged(DependencyObject sender, DependencyProperty dp)
     {


### PR DESCRIPTION
Fixes #425

We didn't handle a potential Infinite width on the `AvailableSize`.. (which happen in edge cases where this control would be in e.g. a `Grid.Column` set to `Auto`. This change makes sure it has a proper fallback. Resolves: #425

Here's an example where the page is rendered in a `Grid.Column` with a `Width` that was set to `Auto`:

![SegmentedPanel](https://user-images.githubusercontent.com/9866362/230624846-50024248-9fe9-41e8-b82a-b5748ec8a11d.gif)

