### PR TITLE
[SettingsControls] Switch to object type for `ItemTemplate` property

### DIFF
--- a/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
+++ b/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
@@ -51,8 +51,8 @@
             </labs:SettingsExpander.ItemsFooter>
         </labs:SettingsExpander>
 
-        <labs:SettingsExpander Description="A SettingsExpander with a custom ItemTemplate."
-                               Header="Settings Expander can use a DataTemplate, DataTemplateSelector, or IElementFactory for its ItemTemplate"
+        <labs:SettingsExpander Description="SettingsExpander can use a DataTemplate, DataTemplateSelector, or IElementFactory for its ItemTemplate."
+                               Header="Settings Expander with a custom ItemTemplate"
                                ItemsSource="{x:Bind MyDataSet}">
             <labs:SettingsExpander.HeaderIcon>
                 <FontIcon Glyph="&#xEA37;" />

--- a/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
+++ b/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
@@ -9,44 +9,85 @@
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
 
-    <labs:SettingsExpander Description="The SettingsExpander can use ItemsSource to define its Items."
-                           Header="Settings Expander with ItemsSource"
-                           ItemsSource="{x:Bind MyDataSet}">
-        <labs:SettingsExpander.HeaderIcon>
-            <FontIcon Glyph="&#xEA37;" />
-        </labs:SettingsExpander.HeaderIcon>
-        <labs:SettingsExpander.ItemTemplate>
-            <DataTemplate x:DataType="local:MyDataModel">
-                <labs:SettingsCard Description="{x:Bind Info}"
-                                   Header="{x:Bind Name}">
-                    <HyperlinkButton Content="{x:Bind LinkDescription}"
-                                     NavigateUri="{x:Bind Url}" />
-                </labs:SettingsCard>
-            </DataTemplate>
-        </labs:SettingsExpander.ItemTemplate>
-        <labs:SettingsExpander.ItemsHeader>
-            <muxc:InfoBar Title="This is the ItemsHeader"
-                          BorderThickness="0"
-                          CornerRadius="0"
-                          IsIconVisible="False"
-                          IsOpen="True"
-                          Severity="Success">
-                <muxc:InfoBar.ActionButton>
-                    <HyperlinkButton Content="It can host custom content" />
-                </muxc:InfoBar.ActionButton>
-            </muxc:InfoBar>
-        </labs:SettingsExpander.ItemsHeader>
-        <labs:SettingsExpander.ItemsFooter>
-            <muxc:InfoBar Title="This is the ItemsFooter"
-                          BorderThickness="0"
-                          CornerRadius="0,0,4,4"
-                          IsIconVisible="False"
-                          IsOpen="True"
-                          Severity="Informational">
-                <muxc:InfoBar.ActionButton>
-                    <HyperlinkButton Content="It can host custom content" />
-                </muxc:InfoBar.ActionButton>
-            </muxc:InfoBar>
-        </labs:SettingsExpander.ItemsFooter>
-    </labs:SettingsExpander>
+    <StackPanel Spacing="3">
+        <labs:SettingsExpander Description="The SettingsExpander can use ItemsSource to define its Items."
+                               Header="Settings Expander with ItemsSource"
+                               ItemsSource="{x:Bind MyDataSet}">
+            <labs:SettingsExpander.HeaderIcon>
+                <FontIcon Glyph="&#xEA37;" />
+            </labs:SettingsExpander.HeaderIcon>
+            <labs:SettingsExpander.ItemTemplate>
+                <DataTemplate x:DataType="local:MyDataModel">
+                    <labs:SettingsCard Description="{x:Bind Info}"
+                                       Header="{x:Bind Name}">
+                        <HyperlinkButton Content="{x:Bind LinkDescription}"
+                                         NavigateUri="{x:Bind Url}" />
+                    </labs:SettingsCard>
+                </DataTemplate>
+            </labs:SettingsExpander.ItemTemplate>
+            <labs:SettingsExpander.ItemsHeader>
+                <muxc:InfoBar Title="This is the ItemsHeader"
+                              BorderThickness="0"
+                              CornerRadius="0"
+                              IsIconVisible="False"
+                              IsOpen="True"
+                              Severity="Success">
+                    <muxc:InfoBar.ActionButton>
+                        <HyperlinkButton Content="It can host custom content" />
+                    </muxc:InfoBar.ActionButton>
+                </muxc:InfoBar>
+            </labs:SettingsExpander.ItemsHeader>
+            <labs:SettingsExpander.ItemsFooter>
+                <muxc:InfoBar Title="This is the ItemsFooter"
+                              BorderThickness="0"
+                              CornerRadius="0,0,4,4"
+                              IsIconVisible="False"
+                              IsOpen="True"
+                              Severity="Informational">
+                    <muxc:InfoBar.ActionButton>
+                        <HyperlinkButton Content="It can host custom content" />
+                    </muxc:InfoBar.ActionButton>
+                </muxc:InfoBar>
+            </labs:SettingsExpander.ItemsFooter>
+        </labs:SettingsExpander>
+
+        <labs:SettingsExpander Description="A SettingsExpander with a custom ItemTemplate."
+                               Header="Settings Expander can use a DataTemplate, DataTemplateSelector, or IElementFactory for its ItemTemplate"
+                               ItemsSource="{x:Bind MyDataSet}">
+            <labs:SettingsExpander.HeaderIcon>
+                <FontIcon Glyph="&#xEA37;" />
+            </labs:SettingsExpander.HeaderIcon>
+            <labs:SettingsExpander.ItemTemplate>
+                <local:MyDataModelTemplateSelector>
+                    <local:MyDataModelTemplateSelector.ButtonTemplate>
+                        <DataTemplate x:DataType="local:MyDataModel">
+                            <labs:SettingsCard Description="{x:Bind ItemType}"
+                                               Header="{x:Bind Name}">
+                                <Button Content="{x:Bind LinkDescription}"
+                                        Click="Button_Click"/>
+                            </labs:SettingsCard>
+                        </DataTemplate>
+                    </local:MyDataModelTemplateSelector.ButtonTemplate>
+
+                    <local:MyDataModelTemplateSelector.LinkButtonTemplate>
+                        <DataTemplate x:DataType="local:MyDataModel">
+                            <labs:SettingsCard Description="{x:Bind ItemType}"
+                                               Header="{x:Bind Name}">
+                                <HyperlinkButton Content="{x:Bind LinkDescription}"
+                                                 NavigateUri="{x:Bind Url}" />
+                            </labs:SettingsCard>
+                        </DataTemplate>
+                    </local:MyDataModelTemplateSelector.LinkButtonTemplate>
+
+                    <local:MyDataModelTemplateSelector.NoButtonTemplate>
+                        <DataTemplate x:DataType="local:MyDataModel">
+                            <labs:SettingsCard Description="{x:Bind ItemType}"
+                                               Header="{x:Bind Name}">
+                            </labs:SettingsCard>
+                        </DataTemplate>
+                    </local:MyDataModelTemplateSelector.NoButtonTemplate>
+                </local:MyDataModelTemplateSelector>
+            </labs:SettingsExpander.ItemTemplate>
+        </labs:SettingsExpander>
+    </StackPanel>
 </Page>

--- a/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
+++ b/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
@@ -63,8 +63,8 @@
                         <DataTemplate x:DataType="local:MyDataModel">
                             <labs:SettingsCard Description="{x:Bind ItemType}"
                                                Header="{x:Bind Name}">
-                                <Button Content="{x:Bind LinkDescription}"
-                                        Click="Button_Click"/>
+                                <Button Click="Button_Click"
+                                        Content="{x:Bind LinkDescription}" />
                             </labs:SettingsCard>
                         </DataTemplate>
                     </local:MyDataModelTemplateSelector.ButtonTemplate>
@@ -82,8 +82,7 @@
                     <local:MyDataModelTemplateSelector.NoButtonTemplate>
                         <DataTemplate x:DataType="local:MyDataModel">
                             <labs:SettingsCard Description="{x:Bind ItemType}"
-                                               Header="{x:Bind Name}">
-                            </labs:SettingsCard>
+                                               Header="{x:Bind Name}" />
                         </DataTemplate>
                     </local:MyDataModelTemplateSelector.NoButtonTemplate>
                 </local:MyDataModelTemplateSelector>

--- a/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml.cs
+++ b/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.ObjectModel;
+using Windows.System;
 
 namespace SettingsControlsExperiment.Samples;
 
@@ -10,11 +10,12 @@ namespace SettingsControlsExperiment.Samples;
 public sealed partial class SettingsExpanderItemsSourceSample : Page
 {
 
-    public ObservableCollection<MyDataModel> MyDataSet = new () {
+    public ObservableCollection<MyDataModel> MyDataSet = new() {
         new()
         {
             Name = "First Item",
             Info = "More about first item.",
+            ItemType = "Item type: Button",
             LinkDescription = "Click here for more on first item.",
             Url = "https://microsoft.com/",
         },
@@ -22,6 +23,7 @@ public sealed partial class SettingsExpanderItemsSourceSample : Page
         {
             Name = "Second Item",
             Info = "More about second item.",
+            ItemType = "Item type: Link button",
             LinkDescription = "Click here for more on second item.",
             Url = "https://xbox.com/",
         },
@@ -29,6 +31,7 @@ public sealed partial class SettingsExpanderItemsSourceSample : Page
         {
             Name = "Third Item",
             Info = "More about third item.",
+            ItemType = "Item type: No button",
             LinkDescription = "Click here for more on third item.",
             Url = "https://toolkitlabs.dev/",
         },
@@ -38,6 +41,11 @@ public sealed partial class SettingsExpanderItemsSourceSample : Page
     {
         this.InitializeComponent();
     }
+
+    private async void Button_Click(object sender, RoutedEventArgs e)
+    {
+        _ = await Launcher.LaunchUriAsync(new("https://microsoft.com/"));
+    }
 }
 
 public class MyDataModel
@@ -46,7 +54,33 @@ public class MyDataModel
 
     public string? Info { get; set; }
 
+    public string? ItemType { get; set; }
+
     public string? LinkDescription { get; set; }
 
     public string? Url { get; set; }
+}
+
+public class MyDataModelTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? ButtonTemplate { get; set; }
+    public DataTemplate? LinkButtonTemplate { get; set; }
+    public DataTemplate? NoButtonTemplate { get; set; }
+
+    protected override DataTemplate SelectTemplateCore(object item)
+    {
+        var itm = (MyDataModel)item;
+        if (itm.ItemType?.EndsWith("Button") == true)
+        {
+            return ButtonTemplate!;
+        }
+        else if (itm.ItemType?.EndsWith("Link button") == true)
+        {
+            return LinkButtonTemplate!;
+        }
+        else
+        {
+            return NoButtonTemplate!;
+        }
+    }
 }

--- a/components/SettingsControls/src/SettingsExpander/SettingsExpander.ItemsControl.cs
+++ b/components/SettingsControls/src/SettingsExpander/SettingsExpander.ItemsControl.cs
@@ -24,14 +24,14 @@ public partial class SettingsExpander
     public static readonly DependencyProperty ItemsSourceProperty =
         DependencyProperty.Register(nameof(ItemsSource), typeof(object), typeof(SettingsExpander), new PropertyMetadata(null, OnItemsConnectedPropertyChanged));
 
-    public DataTemplate ItemTemplate
+    public object ItemTemplate
     {
-        get { return (DataTemplate)GetValue(ItemTemplateProperty); }
+        get { return (object)GetValue(ItemTemplateProperty); }
         set { SetValue(ItemTemplateProperty, value); }
     }
 
     public static readonly DependencyProperty ItemTemplateProperty =
-        DependencyProperty.Register(nameof(ItemTemplate), typeof(DataTemplate), typeof(SettingsExpander), new PropertyMetadata(null));
+        DependencyProperty.Register(nameof(ItemTemplate), typeof(object), typeof(SettingsExpander), new PropertyMetadata(null));
 
     public StyleSelector ItemContainerStyleSelector
     {

--- a/components/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
+++ b/components/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
@@ -99,7 +99,7 @@
                                     <ContentPresenter Content="{TemplateBinding ItemsHeader}" />
                                     <muxc:ItemsRepeater x:Name="PART_ItemsRepeater"
                                                         Grid.Row="1"
-                                                        ItemTemplate="{Binding ItemTemplate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                        ItemTemplate="{TemplateBinding ItemTemplate}"
                                                         TabFocusNavigation="Local">
                                         <muxc:ItemsRepeater.Layout>
                                             <muxc:StackLayout Orientation="Vertical" />

--- a/components/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
+++ b/components/SettingsControls/src/SettingsExpander/SettingsExpander.xaml
@@ -99,7 +99,7 @@
                                     <ContentPresenter Content="{TemplateBinding ItemsHeader}" />
                                     <muxc:ItemsRepeater x:Name="PART_ItemsRepeater"
                                                         Grid.Row="1"
-                                                        ItemTemplate="{TemplateBinding ItemTemplate}"
+                                                        ItemTemplate="{Binding ItemTemplate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
                                                         TabFocusNavigation="Local">
                                         <muxc:ItemsRepeater.Layout>
                                             <muxc:StackLayout Orientation="Vertical" />


### PR DESCRIPTION
The [ItemsRepeater.ItemTemplate](https://learn.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.controls.itemsrepeater.itemtemplate) property allows using a `DataTemplate`, `DataTemplateSelector` or `IElementFactory`. This is quite convenient to have, and to allow for this, the property is of type `IInspectable` (and from C# we see `object` :D)

`SettingsExpander` has an `ItemTemplate` property as well, but it only allows setting a `DataTemplate`, and because of the lack of extra properties in the `ItemsRepeater`, it's not possible to use a template selector or element factory. This PR addresses the problem by switching to object for the `ItemTemplate` property.