### PR TITLE
[TokenView] Fix crash due to unknown brushes

### DIFF
--- a/components/TokenView/samples/TokenViewBasicSample.xaml
+++ b/components/TokenView/samples/TokenViewBasicSample.xaml
@@ -9,9 +9,7 @@
       mc:Ignorable="d">
 
     <Grid>
-        <labs:TokenView AllowDrop="True"
-                        CanReorderItems="True"
-                        IsWrapped="{x:Bind IsWrapped, Mode=OneWay}"
+        <labs:TokenView IsWrapped="{x:Bind IsWrapped, Mode=OneWay}"
                         SelectedIndex="2"
                         SelectionMode="{x:Bind local:TokenViewBasicSample.ConvertStringToListViewSelectionMode(SelectionMode), Mode=OneWay}">
             <labs:TokenItem Content="All" />

--- a/components/TokenView/src/CommunityToolkit.Labs.WinUI.TokenView.csproj
+++ b/components/TokenView/src/CommunityToolkit.Labs.WinUI.TokenView.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ToolkitComponentName>TokenView</ToolkitComponentName>
     <Description>This package contains TokenView.</Description>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.Labs.WinUI.TokenViewRns</RootNamespace>

--- a/components/TokenView/src/TokenItem/TokenItem.xaml
+++ b/components/TokenView/src/TokenItem/TokenItem.xaml
@@ -293,7 +293,7 @@
                                     Padding="2"
                                     CornerRadius="99"
                                     IsTabStop="False"
-                                    Style="{StaticResource SubtleButtonStyle}"
+                                    Style="{StaticResource SubtleAccentButtonStyle}"
                                     Visibility="Collapsed">
                                 <FontIcon FontSize="12"
                                           Glyph="&#xE10A;" />
@@ -307,7 +307,7 @@
 
     <Style x:Key="SubtleAccentButtonStyle"
            TargetType="Button">
-        <Setter Property="Background" Value="{ThemeResource SubtleButtonBackground}" />
+        <Setter Property="Background" Value="{ThemeResource SubtleFillColorTransparent}" />
         <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
         <Setter Property="Foreground" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
         <Setter Property="BorderThickness" Value="0" />
@@ -349,7 +349,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
                                                                        Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="{ThemeResource SubtleButtonBackgroundPointerOver}" />
+                                                                    Value="{ThemeResource SubtleFillColorSecondary}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
                                                                        Storyboard.TargetProperty="Foreground">
@@ -367,7 +367,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
                                                                        Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="{ThemeResource SubtleButtonBackgroundPressed}" />
+                                                                    Value="{ThemeResource SubtleFillColorTertiary}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
                                                                        Storyboard.TargetProperty="Foreground">
@@ -385,7 +385,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
                                                                        Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="{ThemeResource SubtleButtonBackgroundDisabled}" />
+                                                                    Value="{ThemeResource ControlFillColorDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
                                                                        Storyboard.TargetProperty="Foreground">


### PR DESCRIPTION
Should Fix #424

As @willywoe described in #421, `TokenView` crashes whenever a `TokenViewItem` is set to `IsRemoveable`. This shows a remove button that uses brushes that were defined in the Toolkit Labs Gallery project, not in WinUI. That means it would crash.

This PR introduces changes so that it uses the right brushes. No visual changes.