### PR TITLE
[SettingsExpander] SettingsCard as footer sample

### DIFF
--- a/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
+++ b/components/SettingsControls/samples/SettingsExpanderItemsSourceSample.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="SettingsControlsExperiment.Samples.SettingsExpanderItemsSourceSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,7 +8,13 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
-
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///CommunityToolkit.Labs.WinUI.SettingsControls/SettingsExpander/SettingsExpander.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
     <StackPanel Spacing="3">
         <labs:SettingsExpander Description="The SettingsExpander can use ItemsSource to define its Items."
                                Header="Settings Expander with ItemsSource"
@@ -38,16 +44,10 @@
                 </muxc:InfoBar>
             </labs:SettingsExpander.ItemsHeader>
             <labs:SettingsExpander.ItemsFooter>
-                <muxc:InfoBar Title="This is the ItemsFooter"
-                              BorderThickness="0"
-                              CornerRadius="0,0,4,4"
-                              IsIconVisible="False"
-                              IsOpen="True"
-                              Severity="Informational">
-                    <muxc:InfoBar.ActionButton>
-                        <HyperlinkButton Content="It can host custom content" />
-                    </muxc:InfoBar.ActionButton>
-                </muxc:InfoBar>
+                <labs:SettingsCard Header="This is the ItemsFooter"
+                                   Style="{StaticResource DefaultSettingsExpanderItemStyle}">
+                    <Button Content="Add a device" />
+                </labs:SettingsCard>
             </labs:SettingsExpander.ItemsFooter>
         </labs:SettingsExpander>
 


### PR DESCRIPTION
Tweaked the ItemsSource sample a bit so that it's clear how to add a `SettingsCard` as the `ItemsFooter` or `ItemsHeader`:

<img width="596" alt="image" src="https://github.com/CommunityToolkit/Labs-Windows/assets/9866362/2027c9ae-8347-4ecc-8675-6dc118e42392">
