### PR TITLE
Add HasTitleBar, IsResizable, IsMaximizable, IsMinimizable and IsAlwaysOnTop

### DIFF
--- a/components/TitleBar/src/TitleBar.Properties.cs
+++ b/components/TitleBar/src/TitleBar.Properties.cs
@@ -62,6 +62,16 @@ public partial class TitleBar : Control
     /// The backing <see cref="DependencyProperty"/> for the <see cref="Window"/> property.
     /// </summary>
     public static readonly DependencyProperty WindowProperty = DependencyProperty.Register(nameof(Window), typeof(Window), typeof(TitleBar), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty HasTitleBarProperty = DependencyProperty.Register("HasTitleBar", typeof(bool), typeof(TitleBar), new PropertyMetadata(true, OnHasTitleBarChanged));
+
+    public static readonly DependencyProperty IsResizableProperty = DependencyProperty.Register("IsResizable", typeof(bool), typeof(TitleBar), new PropertyMetadata(true, OnIsResizableChanged));
+
+    public static readonly DependencyProperty IsMaximizableProperty = DependencyProperty.Register("IsMaximizable", typeof(bool), typeof(TitleBar), new PropertyMetadata(true, OnIsMaximizableChanged));
+
+    public static readonly DependencyProperty IsMinimizableProperty = DependencyProperty.Register("IsMinimizable", typeof(bool), typeof(TitleBar), new PropertyMetadata(true, OnIsMinimizableChanged));
+
+    public static readonly DependencyProperty IsAlwaysOnTopProperty = DependencyProperty.Register("IsAlwaysOnTop", typeof(bool), typeof(TitleBar), new PropertyMetadata(false, OnIsAlwaysOnTopChanged));
 #endif
 
     /// <summary>
@@ -173,6 +183,36 @@ public partial class TitleBar : Control
         get => (Window)GetValue(WindowProperty);
         set => SetValue(WindowProperty, value);
     }
+
+    public bool HasTitleBar
+    {
+        get { return (bool)GetValue(HasTitleBarProperty); }
+        set { SetValue(HasTitleBarProperty, value); }
+    }
+
+    public bool IsResizable
+    {
+        get { return (bool)GetValue(IsResizableProperty); }
+        set { SetValue(IsResizableProperty, value); }
+    }
+
+    public bool IsMaximizable
+    {
+        get { return (bool)GetValue(IsMaximizableProperty); }
+        set { SetValue(IsMaximizableProperty, value); }
+    }
+
+    public bool IsMinimizable
+    {
+        get { return (bool)GetValue(IsMinimizableProperty); }
+        set { SetValue(IsMinimizableProperty, value); }
+    }
+
+    public bool IsAlwaysOnTop
+    {
+        get { return (bool)GetValue(IsAlwaysOnTopProperty); }
+        set { SetValue(IsAlwaysOnTopProperty, value); }
+    }
 #endif
 
     private static void IsBackButtonVisibleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -206,6 +246,75 @@ public partial class TitleBar : Control
             ((TitleBar)d).Reset();
         }
     }
+
+#if WINAPPSDK
+    private static void OnHasTitleBarChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var titleBar = (TitleBar)d;
+        if (titleBar.Window != null)
+        {
+            if (titleBar.Window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+            {
+                var value = (bool)e.NewValue;
+                var hasBorder = presenter.HasBorder;
+                if (value)
+                {
+                    hasBorder = true;
+                }
+
+                presenter.SetBorderAndTitleBar(hasBorder, value);
+            }
+        }
+    }
+
+    private static void OnIsResizableChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var titleBar = (TitleBar)d;
+        if (titleBar.Window != null)
+        {
+            if (titleBar.Window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+            {
+                presenter.IsResizable = (bool)e.NewValue;
+            }
+        }
+    }
+
+    private static void OnIsMaximizableChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var titleBar = (TitleBar)d;
+        if (titleBar.Window != null)
+        {
+            if (titleBar.Window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+            {
+                presenter.IsMaximizable = (bool)e.NewValue;
+            }
+        }
+    }
+
+    private static void OnIsMinimizableChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var titleBar = (TitleBar)d;
+        if (titleBar.Window != null)
+        {
+            if (titleBar.Window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+            {
+                presenter.IsMinimizable = (bool)e.NewValue;
+            }
+        }
+    }
+
+    private static void OnIsAlwaysOnTopChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var titleBar = (TitleBar)d;
+        if (titleBar.Window != null)
+        {
+            if (titleBar.Window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+            {
+                presenter.IsAlwaysOnTop = (bool)e.NewValue;
+            }
+        }
+    }
+#endif
 }
 
 public enum DisplayMode

--- a/components/TitleBar/src/TitleBar.WASDK.cs
+++ b/components/TitleBar/src/TitleBar.WASDK.cs
@@ -41,6 +41,8 @@ public partial class TitleBar : Control
         {
             Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = true;
 
+            ConfigPresenter();
+
             this.Window.Activated -= Window_Activated;
             this.Window.Activated += Window_Activated;
 
@@ -203,6 +205,18 @@ public partial class TitleBar : Control
 
         uint scaleFactorPercent = (uint)(((long)dpiX * 100 + (96 >> 1)) / 96);
         return scaleFactorPercent / 100.0;
+    }
+
+    private void ConfigPresenter()
+    {
+        if (Window.AppWindow.Presenter is Microsoft.UI.Windowing.OverlappedPresenter presenter)
+        {
+            presenter.IsAlwaysOnTop = IsAlwaysOnTop;
+            presenter.IsResizable = IsResizable;
+            presenter.IsMaximizable = IsMaximizable;
+            presenter.IsMinimizable = IsMinimizable;
+            presenter.SetBorderAndTitleBar(true, HasTitleBar);
+        }
     }
 }
 #endif


### PR DESCRIPTION
Having some of these properties seems necessary.
we can reach the following results:

`IsMaximizable="False"`

![0](https://github.com/CommunityToolkit/Labs-Windows/assets/9213496/c0e6e927-4f00-450b-b14f-b5d2154f5da2)

`IsMinimizable="False"`

![1](https://github.com/CommunityToolkit/Labs-Windows/assets/9213496/55afd28d-4d53-44d3-b862-d293d458610f)

```
HasTitleBar="False"
IsResizable="False"
```

![2](https://github.com/CommunityToolkit/Labs-Windows/assets/9213496/3139de65-8415-403a-ba90-16789eebb2b6)
