### PR TITLE
Fix PaneButton not clickable

### DIFF
--- a/components/TitleBar/src/TitleBar.cs
+++ b/components/TitleBar/src/TitleBar.cs
@@ -24,6 +24,7 @@ namespace CommunityToolkit.WinUI.Controls;
 [TemplatePart(Name = PartPaneButton, Type = typeof(Button))]
 [TemplatePart(Name = nameof(PART_LeftPaddingColumn), Type = typeof(ColumnDefinition))]
 [TemplatePart(Name = nameof(PART_RightPaddingColumn), Type = typeof(ColumnDefinition))]
+[TemplatePart(Name = nameof(PART_ButtonHolder), Type = typeof(StackPanel))]
 
 public partial class TitleBar : Control
 {
@@ -64,6 +65,7 @@ public partial class TitleBar : Control
 
     ColumnDefinition? PART_LeftPaddingColumn;
     ColumnDefinition? PART_RightPaddingColumn;
+    StackPanel? PART_ButtonHolder;
 
     public TitleBar()
     {
@@ -75,6 +77,7 @@ public partial class TitleBar : Control
         PART_LeftPaddingColumn = GetTemplateChild(nameof(PART_LeftPaddingColumn)) as ColumnDefinition;
         PART_RightPaddingColumn = GetTemplateChild(nameof(PART_RightPaddingColumn)) as ColumnDefinition;
         Configure();
+        ConfigureButtonHolder();
         if (GetTemplateChild(PartBackButton) is Button backButton)
         {
             backButton.Click -= BackButton_Click;
@@ -122,6 +125,28 @@ public partial class TitleBar : Control
     private void PaneButton_Click(object sender, RoutedEventArgs e)
     {
         PaneButtonClick?.Invoke(this, new RoutedEventArgs());
+    }
+
+    private void ConfigureButtonHolder()
+    {
+        if (PART_ButtonHolder != null)
+        {
+            PART_ButtonHolder.SizeChanged -= PART_ButtonHolder_SizeChanged;
+        }
+
+        PART_ButtonHolder = GetTemplateChild(nameof(PART_ButtonHolder)) as StackPanel;
+
+        if(PART_ButtonHolder != null)
+        {
+            PART_ButtonHolder.SizeChanged += PART_ButtonHolder_SizeChanged;
+        }
+    }
+
+    private void PART_ButtonHolder_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+#if WINAPPSDK
+        SetDragRegionForCustomTitleBar();
+#endif
     }
 
     private void Configure()

--- a/components/TitleBar/src/TitleBar.xaml
+++ b/components/TitleBar/src/TitleBar.xaml
@@ -165,7 +165,7 @@
                               Grid.Column="2"
                               Grid.ColumnSpan="6"
                               Background="Transparent" />
-                        <StackPanel x:Name="ButtonHolder"
+                        <StackPanel x:Name="PART_ButtonHolder"
                                     Grid.Column="1"
                                     Orientation="Horizontal">
                             <Button x:Name="PART_BackButton"


### PR DESCRIPTION
This can fix PaneButton not clickable
![image](https://github.com/CommunityToolkit/Labs-Windows/assets/9213496/76038a6b-8dc9-4b71-be9a-df1591e3b6be)
