### PR TITLE
[DataTable] Update to release dependencies and fix Padding value for Sizer in DataColumn

### DIFF
--- a/components/CanvasView/src/Dependencies.props
+++ b/components/CanvasView/src/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.0.230907"/>
   </ItemGroup>
 </Project>

--- a/components/DataTable/samples/Dependencies.props
+++ b/components/DataTable/samples/Dependencies.props
@@ -11,14 +11,14 @@
 <Project>
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230801-preview"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.0.230907"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230801-preview"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.0.230907"/>
     </ItemGroup>
 
     <!-- WinUI 2 / UWP -->

--- a/components/DataTable/src/DataTable/DataColumn.xaml
+++ b/components/DataTable/src/DataTable/DataColumn.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
@@ -38,11 +38,11 @@
                                                    Width="8"
                                                    MinWidth="4"
                                                    Margin="0"
+                                                   Padding="0"
                                                    Background="Transparent"
                                                    Foreground="{ThemeResource ControlStrokeColorSecondaryBrush}"
                                                    Visibility="{Binding CanResize, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource DataColumnBoolToVisibilityConverter}}">
                                 <controls:ContentSizer.Resources>
-                                    <Thickness x:Key="SizerBaseThumbMargin">0</Thickness>
                                     <x:Double x:Key="SizerBaseThumbWidth">2</x:Double>
                                     <x:Double x:Key="SizerBaseThumbHeight">16</x:Double>
                                 </controls:ContentSizer.Resources>

--- a/components/DataTable/src/Dependencies.props
+++ b/components/DataTable/src/Dependencies.props
@@ -14,15 +14,15 @@
   
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.0.230801-preview"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.0.230801-preview"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.0.230907"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.230801-preview"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.0.230801-preview"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.230907"/>
     </ItemGroup>
 </Project>

--- a/components/RivePlayer/samples/Dependencies.props
+++ b/components/RivePlayer/samples/Dependencies.props
@@ -12,24 +12,24 @@
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230907"/>
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
         <!-- <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230907"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
         <!-- <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230907"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
         <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.100-dev.15.g12261e2626"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230801-preview"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230907"/>
     </ItemGroup>
 </Project>

--- a/components/Shimmer/src/Dependencies.props
+++ b/components/Shimmer/src/Dependencies.props
@@ -12,24 +12,24 @@
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
     <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.3"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230801-preview" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230907" />
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
     <!--  <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230801-preview" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230907" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
     <!-- <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230801-preview" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230907" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
     <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230801-preview" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230907" />
   </ItemGroup>
 </Project>

--- a/components/TokenView/src/Dependencies.props
+++ b/components/TokenView/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.230907"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/samples/Dependencies.props
+++ b/components/TransitionHelper/samples/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230907"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/src/Dependencies.props
+++ b/components/TransitionHelper/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230907"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230801-preview"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230801-preview"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.0.230907"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230907"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Simple update to fix issue with DataColumn sizer display (and update to the latest dependencies)

Before, Sizer was invisible, could tell it was there from hover effect though:
![image](https://github.com/CommunityToolkit/Labs-Windows/assets/24302614/e0f0b1a3-1818-49f2-94a9-97add48163ab)

After, Sizer appears again:
![image](https://github.com/CommunityToolkit/Labs-Windows/assets/24302614/3ee7a7bf-7579-4a22-8fd9-bd05c17f62e8)

Tested on UWP and WASDK

Forgot that I don't have to update a Version field anymore, woot! 🎉 (though guess it means it respits out all the packages still...)

Note requires update to sub-module as we weren't on latest package versions of shipped 8.0. Think there was an issue/discussion mentioning this somewhere as well? FYI @Arlodotexe 