### PR TITLE
[Shimmer] Invert dark theme colors

### DIFF
--- a/components/Shimmer/src/Shimmer/Shimmer.cs
+++ b/components/Shimmer/src/Shimmer/Shimmer.cs
@@ -159,10 +159,10 @@ public partial class Shimmer : Control
         {
             case ElementTheme.Default:
             case ElementTheme.Dark:
-                _gradientStop1!.Color = Color.FromArgb((byte)(255 * 3.26 / 100), 255, 255, 255);
-                _gradientStop2!.Color = Color.FromArgb((byte)(255 * 6.05 / 100), 255, 255, 255);
-                _gradientStop3!.Color = Color.FromArgb((byte)(255 * 6.05 / 100), 255, 255, 255);
-                _gradientStop4!.Color = Color.FromArgb((byte)(255 * 3.26 / 100), 255, 255, 255);
+                _gradientStop1!.Color = Color.FromArgb((byte)(255 * 6.05 / 100), 255, 255, 255);
+                _gradientStop2!.Color = Color.FromArgb((byte)(255 * 3.26 / 100), 255, 255, 255);
+                _gradientStop3!.Color = Color.FromArgb((byte)(255 * 3.26 / 100), 255, 255, 255);
+                _gradientStop4!.Color = Color.FromArgb((byte)(255 * 6.05 / 100), 255, 255, 255);
                 break;
             case ElementTheme.Light:
                 _gradientStop1!.Color = Color.FromArgb((byte)(255 * 5.37 / 100), 0, 0, 0);


### PR DESCRIPTION
Currently, the shimmers are difficult to see in dark mode. This change makes them easier to see.

I believe this is because the colors got transposed: for *light mode*, the **more translucent** color is used for 2 & 3, whereas currently for light mode, the **less translucent** color is used for 2 & 3. My _hunch_ is that this intended to account for the inversion in color b/w dark & light mode, but that's already accounted for because the colors themselves are inverted b/w those modes.

In other words, both the colors _and_ the translucencies were transposed, when only one should have been.

Before:

![DarkShimmerBefore](https://github.com/CommunityToolkit/Labs-Windows/assets/9866362/8c48bf11-1ff4-4ef4-91f3-fbb7d4fe282d)

After:

![DarkShimmerAfter](https://github.com/CommunityToolkit/Labs-Windows/assets/9866362/73a99827-a734-4b42-9a16-bf0ecc8aaf79)

## What changed?

* Swapped the translucencies in the dark mode colors.

## How tested?

Tested using our C++ port of this code.