### PR TITLE
Improved MarqueeText control

### DIFF
--- a/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarqueeTextExperiment.Samples.CustomStyleMarqueeTextSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,9 +11,9 @@
 
     <StackPanel Padding="16">
         <labs:MarqueeText x:Name="Marquee"
-                          Text="{x:Bind MQText, Mode=OneWay}"
                           Behavior="Cycle"
-                          FontSize="18">
+                          FontSize="18"
+                          Text="{x:Bind MQText, Mode=OneWay}">
             <labs:MarqueeText.Style>
                 <Style TargetType="labs:MarqueeText">
                     <Setter Property="IsTabStop" Value="False" />
@@ -28,6 +28,56 @@
                                       BorderBrush="{TemplateBinding BorderBrush}"
                                       BorderThickness="{TemplateBinding BorderThickness}"
                                       CornerRadius="{TemplateBinding CornerRadius}">
+
+                                    <Grid.Resources>
+                                        <Storyboard x:Name="CyclingAnimation"
+                                                    Duration="0:0:0.5">
+                                            <!--  Animate out  -->
+                                            <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"
+                                                                           Storyboard.TargetName="MarqueeTransform"
+                                                                           Storyboard.TargetProperty="(CompositeTransform.Rotation)"
+                                                                           Duration="0:0:1.2">
+                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0"
+                                                                        Value="0" />
+                                                <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition"
+                                                                      KeyTime="0:0:0.2"
+                                                                      Value="20" />
+                                                <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition"
+                                                                        KeyTime="0:0:0.3"
+                                                                        Value="-20" />
+                                                <LinearDoubleKeyFrame KeyTime="0:0:0.5"
+                                                                      Value="0" />
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <!--  Animate the opacity  -->
+                                            <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MarqueePanel"
+                                                                           Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                                           Duration="0:0:1.2">
+                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0"
+                                                                        Value="1" />
+                                                <LinearDoubleKeyFrame KeyTime="0:0:0.2"
+                                                                      Value="0" />
+                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0.3"
+                                                                        Value="0" />
+                                                <LinearDoubleKeyFrame KeyTime="0:0:0.5"
+                                                                      Value="1" />
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <!--  Toggle the visible segment between fade out and fade in  -->
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Segment2"
+                                                                           Storyboard.TargetProperty="(UIElement.Visibility)">
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0"
+                                                                        Value="Visible" />
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0.25"
+                                                                        Value="Collapsed" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Segment1"
+                                                                           Storyboard.TargetProperty="(UIElement.Visibility)">
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0"
+                                                                        Value="Collapsed" />
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0.25"
+                                                                        Value="Visible" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </Grid.Resources>
                                     <VisualStateManager.VisualStateGroups>
                                         <VisualStateGroup x:Name="MarqueeStateGroup">
                                             <VisualState x:Name="MarqueeActive" />
@@ -87,41 +137,13 @@
                                             </VisualState>
                                         </VisualStateGroup>
                                     </VisualStateManager.VisualStateGroups>
-            
-                                    <Grid.Resources>
-                                        <Storyboard x:Name="CyclingAnimation" Duration="0:0:0.5">
-                                            <!--Animate out-->
-                                            <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation" Duration="0:0:1.2" Storyboard.TargetProperty="(CompositeTransform.Rotation)" Storyboard.TargetName="MarqueeTransform">
-                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
-                                                <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition" KeyTime="0:0:0.2" Value="20"/>
-                                                <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition" KeyTime="0:0:0.3" Value="-20"/>
-                                                <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="0"/>
-                                            </DoubleAnimationUsingKeyFrames>
-                                            <!--Animate the opacity-->
-                                            <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="MarqueePanel">
-                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1"/>
-                                                <LinearDoubleKeyFrame KeyTime="0:0:0.2" Value="0"/>
-                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
-                                                <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="1"/>
-                                            </DoubleAnimationUsingKeyFrames>
-                                            <!--Toggle the visible segment between fade out and fade in-->
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment2">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible"/>
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0.25" Value="Collapsed"/>
-                                            </ObjectAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment1">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Collapsed"/>
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0.25" Value="Visible"/>
-                                            </ObjectAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                    </Grid.Resources>
-                                    
+
                                     <Grid x:Name="MarqueeContainer">
                                         <StackPanel x:Name="MarqueePanel"
                                                     Orientation="Horizontal"
                                                     RenderTransformOrigin="0,0.5">
                                             <StackPanel.RenderTransform>
-                                                <CompositeTransform x:Name="MarqueeTransform"/>
+                                                <CompositeTransform x:Name="MarqueeTransform" />
                                             </StackPanel.RenderTransform>
                                             <TextBlock x:Name="Segment1"
                                                        win:FontStretch="{TemplateBinding FontStretch}"
@@ -132,7 +154,7 @@
                                                        FontStyle="{TemplateBinding FontStyle}"
                                                        FontWeight="{TemplateBinding FontWeight}"
                                                        Foreground="{TemplateBinding Foreground}"
-                                                       Text="{TemplateBinding Text}"/>
+                                                       Text="{TemplateBinding Text}" />
                                             <TextBlock x:Name="Segment2"
                                                        win:FontStretch="{TemplateBinding FontStretch}"
                                                        win:TextDecorations="{TemplateBinding TextDecorations}"
@@ -143,7 +165,7 @@
                                                        FontWeight="{TemplateBinding FontWeight}"
                                                        Foreground="{TemplateBinding Foreground}"
                                                        Text="{TemplateBinding SecondaryText}"
-                                                       Visibility="Collapsed"/>
+                                                       Visibility="Collapsed" />
                                         </StackPanel>
                                     </Grid>
                                 </Grid>

--- a/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarqueeTextExperiment.Samples.CustomStyleMarqueeTextSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,7 +11,7 @@
 
     <StackPanel Padding="16">
         <labs:MarqueeText x:Name="Marquee"
-                          Behavior="Cycle"
+                          Behavior="Transition"
                           FontSize="18"
                           Text="{x:Bind MQText, Mode=OneWay}">
             <labs:MarqueeText.Style>
@@ -30,19 +30,19 @@
                                       CornerRadius="{TemplateBinding CornerRadius}">
 
                                     <Grid.Resources>
-                                        <Storyboard x:Name="CyclingAnimation"
+                                        <Storyboard x:Name="TransitionAnimation"
                                                     Duration="0:0:0.5">
                                             <!--  Animate out  -->
-                                            <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"
+                                            <DoubleAnimationUsingKeyFrames x:Name="TransitionAnimationTranslationAnimation"
                                                                            Storyboard.TargetName="MarqueeTransform"
                                                                            Storyboard.TargetProperty="(CompositeTransform.Rotation)"
                                                                            Duration="0:0:1.2">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0"
                                                                         Value="0" />
-                                                <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition"
+                                                <LinearDoubleKeyFrame x:Name="TransitionAnimationFadeOutPosition"
                                                                       KeyTime="0:0:0.2"
                                                                       Value="20" />
-                                                <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition"
+                                                <DiscreteDoubleKeyFrame x:Name="TransitionAnimationFadeInPosition"
                                                                         KeyTime="0:0:0.3"
                                                                         Value="-20" />
                                                 <LinearDoubleKeyFrame KeyTime="0:0:0.5"
@@ -129,7 +129,7 @@
                                                     <Setter Target="Segment2.Visibility" Value="Collapsed" />
                                                 </VisualState.Setters>
                                             </VisualState>
-                                            <VisualState x:Name="Cycle">
+                                            <VisualState x:Name="Transition">
                                                 <VisualState.Setters>
                                                     <Setter Target="Segment1.Padding" Value="0" />
                                                     <Setter Target="Segment2.Visibility" Value="Collapsed" />

--- a/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarqueeTextExperiment.Samples.CustomStyleMarqueeTextSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,8 +11,8 @@
 
     <StackPanel Padding="16">
         <labs:MarqueeText x:Name="Marquee"
+                          Behavior="Cycle"
                           FontSize="18"
-                          StartOnTextChanged="True"
                           Text="{x:Bind MQText, Mode=OneWay}">
             <labs:MarqueeText.Style>
                 <Style TargetType="labs:MarqueeText">
@@ -30,7 +30,7 @@
                                       CornerRadius="{TemplateBinding CornerRadius}">
 
                                     <Grid.Resources>
-                                        <Storyboard x:Name="MarqueeAnimation"
+                                        <Storyboard x:Name="CyclingAnimation"
                                                     Duration="0:0:0.5">
                                             <!--  Animate out  -->
                                             <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"

--- a/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
@@ -1,0 +1,157 @@
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="MarqueeTextExperiment.Samples.CustomStyleMarqueeTextSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarqueeTextRns"
+      xmlns:local="MarqueeTextExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      mc:Ignorable="d">
+
+    <StackPanel Padding="16">
+        <labs:MarqueeText x:Name="Marquee"
+                          Text="{x:Bind MQText, Mode=OneWay}"
+                          Behavior="Cycle"
+                          FontSize="18">
+            <labs:MarqueeText.Style>
+                <Style TargetType="labs:MarqueeText">
+                    <Setter Property="IsTabStop" Value="False" />
+                    <Setter Property="VerticalAlignment" Value="Top" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="labs:MarqueeText">
+                                <Grid Padding="{TemplateBinding Padding}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                      Background="{TemplateBinding Background}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      CornerRadius="{TemplateBinding CornerRadius}">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="MarqueeStateGroup">
+                                            <VisualState x:Name="MarqueeActive" />
+                                            <VisualState x:Name="MarqueeStopped">
+                                                <VisualState.Setters>
+                                                    <Setter Target="MarqueeTransform.TranslateX" Value="0.0" />
+                                                    <Setter Target="MarqueeTransform.TranslateY" Value="0.0" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                        <VisualStateGroup x:Name="DirectionStateGroup">
+                                            <VisualState x:Name="Leftwards">
+                                                <VisualState.Setters>
+                                                    <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Rightwards">
+                                                <VisualState.Setters>
+                                                    <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Upwards">
+                                                <VisualState.Setters>
+                                                    <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Downwards">
+                                                <VisualState.Setters>
+                                                    <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                        <VisualStateGroup x:Name="BehaviorStateGroup">
+                                            <VisualState x:Name="Ticker">
+                                                <VisualState.Setters>
+                                                    <Setter Target="Segment1.Padding" Value="0" />
+                                                    <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Looping">
+                                                <VisualState.Setters>
+                                                    <Setter Target="Segment1.Padding" Value="0,0,32,0" />
+                                                    <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Bouncing">
+                                                <VisualState.Setters>
+                                                    <Setter Target="Segment1.Padding" Value="0" />
+                                                    <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                            <VisualState x:Name="Cycle">
+                                                <VisualState.Setters>
+                                                    <Setter Target="Segment1.Padding" Value="0" />
+                                                    <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+            
+                                    <Grid.Resources>
+                                        <Storyboard x:Name="CyclingAnimation" Duration="0:0:0.5">
+                                            <!--Animate out-->
+                                            <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation" Duration="0:0:1.2" Storyboard.TargetProperty="(CompositeTransform.Rotation)" Storyboard.TargetName="MarqueeTransform">
+                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
+                                                <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition" KeyTime="0:0:0.2" Value="20"/>
+                                                <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition" KeyTime="0:0:0.3" Value="-20"/>
+                                                <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="0"/>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <!--Animate the opacity-->
+                                            <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="MarqueePanel">
+                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1"/>
+                                                <LinearDoubleKeyFrame KeyTime="0:0:0.2" Value="0"/>
+                                                <DiscreteDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
+                                                <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="1"/>
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <!--Toggle the visible segment between fade out and fade in-->
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment2">
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible"/>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0.25" Value="Collapsed"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment1">
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Collapsed"/>
+                                                <DiscreteObjectKeyFrame KeyTime="0:0:0.25" Value="Visible"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </Grid.Resources>
+                                    
+                                    <Grid x:Name="MarqueeContainer">
+                                        <StackPanel x:Name="MarqueePanel"
+                                                    Orientation="Horizontal"
+                                                    RenderTransformOrigin="0,0.5">
+                                            <StackPanel.RenderTransform>
+                                                <CompositeTransform x:Name="MarqueeTransform"/>
+                                            </StackPanel.RenderTransform>
+                                            <TextBlock x:Name="Segment1"
+                                                       win:FontStretch="{TemplateBinding FontStretch}"
+                                                       win:TextDecorations="{TemplateBinding TextDecorations}"
+                                                       CharacterSpacing="{TemplateBinding CharacterSpacing}"
+                                                       FontFamily="{TemplateBinding FontFamily}"
+                                                       FontSize="{TemplateBinding FontSize}"
+                                                       FontStyle="{TemplateBinding FontStyle}"
+                                                       FontWeight="{TemplateBinding FontWeight}"
+                                                       Foreground="{TemplateBinding Foreground}"
+                                                       Text="{TemplateBinding Text}"/>
+                                            <TextBlock x:Name="Segment2"
+                                                       win:FontStretch="{TemplateBinding FontStretch}"
+                                                       win:TextDecorations="{TemplateBinding TextDecorations}"
+                                                       CharacterSpacing="{TemplateBinding CharacterSpacing}"
+                                                       FontFamily="{TemplateBinding FontFamily}"
+                                                       FontSize="{TemplateBinding FontSize}"
+                                                       FontStyle="{TemplateBinding FontStyle}"
+                                                       FontWeight="{TemplateBinding FontWeight}"
+                                                       Foreground="{TemplateBinding Foreground}"
+                                                       Text="{TemplateBinding SecondaryText}"
+                                                       Visibility="Collapsed"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </labs:MarqueeText.Style>
+        </labs:MarqueeText>
+    </StackPanel>
+</Page>

--- a/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarqueeTextExperiment.Samples.CustomStyleMarqueeTextSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,8 +11,8 @@
 
     <StackPanel Padding="16">
         <labs:MarqueeText x:Name="Marquee"
-                          Behavior="Cycle"
                           FontSize="18"
+                          StartOnTextChanged="True"
                           Text="{x:Bind MQText, Mode=OneWay}">
             <labs:MarqueeText.Style>
                 <Style TargetType="labs:MarqueeText">
@@ -30,7 +30,7 @@
                                       CornerRadius="{TemplateBinding CornerRadius}">
 
                                     <Grid.Resources>
-                                        <Storyboard x:Name="CyclingAnimation"
+                                        <Storyboard x:Name="MarqueeAnimation"
                                                     Duration="0:0:0.5">
                                             <!--  Animate out  -->
                                             <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"

--- a/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml.cs
+++ b/components/MarqueeText/samples/CustomStyleMarqueeTextSample.xaml.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Labs.WinUI.MarqueeTextRns;
+
+namespace MarqueeTextExperiment.Samples;
+
+[ToolkitSample(id: nameof(CustomStyleMarqueeTextSample), "MarqueeText", description: "A control for scrolling text in a marquee fashion.")]
+[ToolkitSampleTextOption("MQText", LoremIpsum, Title = "Text")]
+//[ToolkitSampleMultiChoiceOption("MarqueeRepeat", "Repeat", "Forever", "1x", "2x")]
+public sealed partial class CustomStyleMarqueeTextSample : Page
+{
+    private const string LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+    public CustomStyleMarqueeTextSample()
+    {
+        this.InitializeComponent();
+    }
+
+    private MarqueeDirection ConvertStringToMarqueeDirection(string str) => str switch
+    {
+        "Left" => MarqueeDirection.Left,
+        "Up" => MarqueeDirection.Up,
+        "Right" => MarqueeDirection.Right,
+        "Down" => MarqueeDirection.Down,
+        _ => throw new System.NotImplementedException(),
+    };
+}

--- a/components/MarqueeText/samples/MarqueeText.Samples.csproj
+++ b/components/MarqueeText/samples/MarqueeText.Samples.csproj
@@ -17,9 +17,17 @@
 
   <ItemGroup>
     <None Remove="Assets\MarqueeText.png" />
+    <None Remove="CustomStyleMarqueeTextSample.xaml" />
+    <UpToDateCheckInput Remove="CustomStyleMarqueeTextSample.xaml" />
 
     <Content Include="Assets\MarqueeText.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="CustomStyleMarqueeTextSample.xaml.cs">
+      <DependentUpon>CustomStyleMarqueeTextSample.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/components/MarqueeText/samples/MarqueeText.md
+++ b/components/MarqueeText/samples/MarqueeText.md
@@ -44,3 +44,9 @@ The repeat behavior determines how many times the marquee will loop before the a
 The default direction is left, meaning the text will move leftwards, but this can be changed to right, up, or down. Direction changed between left and right or up and down are handled continously, meaning that the animation will resume from its current position if changed between these directions.
 
 > [!Sample MarqueeTextSample]
+
+### Custom Cycle Animations
+
+The cycle animation can be customized using a style.
+
+> [!Sample CustomStyleMarqueeTextSample]

--- a/components/MarqueeText/samples/MarqueeText.md
+++ b/components/MarqueeText/samples/MarqueeText.md
@@ -45,8 +45,8 @@ The default direction is left, meaning the text will move leftwards, but this ca
 
 > [!Sample MarqueeTextSample]
 
-### Custom Cycle Animations
+### Custom Transition Animations
 
-The cycle animation can be customized using a style.
+The transition animation can be customized using a style.
 
 > [!Sample CustomStyleMarqueeTextSample]

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml
@@ -9,11 +9,11 @@
       mc:Ignorable="d">
 
     <StackPanel Padding="16">
-        <labs:MarqueeText Behavior="{x:Bind ConvertStringToMarqueeBehavior(MQBehavior), Mode=OneWay}"
+        <labs:MarqueeText Text="{x:Bind MQText, Mode=OneWay}"
+                          Behavior="{x:Bind ConvertStringToMarqueeBehavior(MQBehavior), Mode=OneWay}"
                           Direction="{x:Bind ConvertStringToMarqueeDirection(MQDirection), Mode=OneWay}"
                           FontSize="18"
                           RepeatBehavior="Forever"
-                          Speed="{x:Bind MQSpeed, Mode=OneWay}"
-                          Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." />
+                          Speed="{x:Bind MQSpeed, Mode=OneWay}"/>
     </StackPanel>
 </Page>

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml
@@ -9,11 +9,14 @@
       mc:Ignorable="d">
 
     <StackPanel Padding="16">
-        <labs:MarqueeText Text="{x:Bind MQText, Mode=OneWay}"
+        <labs:MarqueeText x:Name="Marquee"
+                          Text="{x:Bind MQText, Mode=OneWay}"
                           Behavior="{x:Bind ConvertStringToMarqueeBehavior(MQBehavior), Mode=OneWay}"
                           Direction="{x:Bind ConvertStringToMarqueeDirection(MQDirection), Mode=OneWay}"
                           FontSize="18"
                           RepeatBehavior="Forever"
                           Speed="{x:Bind MQSpeed, Mode=OneWay}"/>
+
+        <Button Content="Start Marquee" Click="StartMarquee_Click" Margin="0,8"/>
     </StackPanel>
 </Page>

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarqueeTextExperiment.Samples.MarqueeTextSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,13 +10,15 @@
 
     <StackPanel Padding="16">
         <labs:MarqueeText x:Name="Marquee"
-                          Text="{x:Bind MQText, Mode=OneWay}"
                           Behavior="{x:Bind ConvertStringToMarqueeBehavior(MQBehavior), Mode=OneWay}"
                           Direction="{x:Bind ConvertStringToMarqueeDirection(MQDirection), Mode=OneWay}"
                           FontSize="18"
                           RepeatBehavior="Forever"
-                          Speed="{x:Bind MQSpeed, Mode=OneWay}"/>
+                          Speed="{x:Bind MQSpeed, Mode=OneWay}"
+                          Text="{x:Bind MQText, Mode=OneWay}" />
 
-        <Button Content="Start Marquee" Click="StartMarquee_Click" Margin="0,8"/>
+        <Button Margin="0,8"
+                Click="StartMarquee_Click"
+                Content="Start Marquee" />
     </StackPanel>
 </Page>

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarqueeTextExperiment.Samples.MarqueeTextSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,7 +10,6 @@
 
     <StackPanel Padding="16">
         <labs:MarqueeText x:Name="Marquee"
-                          Behavior="{x:Bind ConvertStringToMarqueeBehavior(MQBehavior), Mode=OneWay}"
                           Direction="{x:Bind ConvertStringToMarqueeDirection(MQDirection), Mode=OneWay}"
                           FontSize="18"
                           RepeatBehavior="Forever"

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarqueeTextExperiment.Samples.MarqueeTextSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,6 +10,7 @@
 
     <StackPanel Padding="16">
         <labs:MarqueeText x:Name="Marquee"
+                          Behavior="{x:Bind ConvertStringToMarqueeBehavior(MQBehavior), Mode=OneWay}"
                           Direction="{x:Bind ConvertStringToMarqueeDirection(MQDirection), Mode=OneWay}"
                           FontSize="18"
                           RepeatBehavior="Forever"

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
@@ -10,9 +10,9 @@ namespace MarqueeTextExperiment.Samples;
 [ToolkitSampleMultiChoiceOption("MQDirection", "Left", "Right", "Up", "Down", Title = "Marquee Direction")]
 //[ToolkitSampleMultiChoiceOption("MarqueeRepeat", "Repeat", "Forever", "1x", "2x")]
 #if !HAS_UNO
-[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", "Bouncing", Title = "Marquee Behavior")]
+[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", "Bouncing", "Cycle", Title = "Marquee Behavior")]
 #else
-[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", Title = "Marquee Behavior")]
+[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", "Cycle", Title = "Marquee Behavior")]
 #endif
 public sealed partial class MarqueeTextSample : Page
 {
@@ -28,7 +28,8 @@ public sealed partial class MarqueeTextSample : Page
 #if !HAS_UNO
         "Bouncing" => MarqueeBehavior.Bouncing,
 #endif
-        _ => throw new System.NotImplementedException(),
+        "Cycle" => MarqueeBehavior.Cycle,
+        _ => throw new NotImplementedException(),
     };
 
     private MarqueeDirection ConvertStringToMarqueeDirection(string str) => str switch

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
@@ -12,9 +12,9 @@ namespace MarqueeTextExperiment.Samples;
 [ToolkitSampleMultiChoiceOption("MQDirection", "Left", "Right", "Up", "Down", Title = "Marquee Direction")]
 //[ToolkitSampleMultiChoiceOption("MarqueeRepeat", "Repeat", "Forever", "1x", "2x")]
 #if !HAS_UNO
-[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", "Bouncing", "Cycle", Title = "Marquee Behavior")]
+[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", "Bouncing", "Transition", Title = "Marquee Behavior")]
 #else
-[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", "Cycle", Title = "Marquee Behavior")]
+[ToolkitSampleMultiChoiceOption("MQBehavior", "Ticker", "Looping", "Transition", Title = "Marquee Behavior")]
 #endif
 public sealed partial class MarqueeTextSample : Page
 {
@@ -32,7 +32,7 @@ public sealed partial class MarqueeTextSample : Page
 #if !HAS_UNO
         "Bouncing" => MarqueeBehavior.Bouncing,
 #endif
-        "Cycle" => MarqueeBehavior.Cycle,
+        "Transition" => MarqueeBehavior.Transition,
         _ => throw new NotImplementedException(),
     };
 

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
@@ -44,4 +44,9 @@ public sealed partial class MarqueeTextSample : Page
         "Down" => MarqueeDirection.Down,
         _ => throw new System.NotImplementedException(),
     };
+
+    private void StartMarquee_Click(object sender, RoutedEventArgs e)
+    {
+        Marquee?.StartMarquee();
+    }
 }

--- a/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
+++ b/components/MarqueeText/samples/MarqueeTextSample.xaml.cs
@@ -5,7 +5,9 @@
 using CommunityToolkit.Labs.WinUI.MarqueeTextRns;
 
 namespace MarqueeTextExperiment.Samples;
+
 [ToolkitSample(id: nameof(MarqueeTextSample), "MarqueeText", description: "A control for scrolling text in a marquee fashion.")]
+[ToolkitSampleTextOption("MQText", LoremIpsum, Title = "Text")]
 [ToolkitSampleNumericOption("MQSpeed", initial: 96, min: 48, max: 196, step: 1, Title = "Speed")]
 [ToolkitSampleMultiChoiceOption("MQDirection", "Left", "Right", "Up", "Down", Title = "Marquee Direction")]
 //[ToolkitSampleMultiChoiceOption("MarqueeRepeat", "Repeat", "Forever", "1x", "2x")]
@@ -16,6 +18,8 @@ namespace MarqueeTextExperiment.Samples;
 #endif
 public sealed partial class MarqueeTextSample : Page
 {
+    private const string LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
     public MarqueeTextSample()
     {
         this.InitializeComponent();

--- a/components/MarqueeText/src/MarqueeBehavior.cs
+++ b/components/MarqueeText/src/MarqueeBehavior.cs
@@ -29,4 +29,9 @@ public enum MarqueeBehavior
     /// </summary>
     Bouncing,
 #endif
+
+    /// <summary>
+    /// The text will cycle fading between a list of statements.
+    /// </summary>
+    Cycle,
 }

--- a/components/MarqueeText/src/MarqueeBehavior.cs
+++ b/components/MarqueeText/src/MarqueeBehavior.cs
@@ -31,7 +31,7 @@ public enum MarqueeBehavior
 #endif
 
     /// <summary>
-    /// The text will cycle fading between a list of statements.
+    /// The text will transition when the text property changes.
     /// </summary>
-    Cycle,
+    Transition,
 }

--- a/components/MarqueeText/src/MarqueeDirection.cs
+++ b/components/MarqueeText/src/MarqueeDirection.cs
@@ -10,22 +10,22 @@ namespace CommunityToolkit.Labs.WinUI.MarqueeTextRns;
 public enum MarqueeDirection
 {
     /// <summary>
-    /// The text will flow from left to right.
+    /// The text will move from left to right.
     /// </summary>
     Left,
 
     /// <summary>
-    /// The text will flow from right to left.
+    /// The text will move from right to left.
     /// </summary>
     Right,
 
     /// <summary>
-    /// The text will flow from bottom to top.
+    /// The text will move from bottom to top.
     /// </summary>
     Up,
 
     /// <summary>
-    /// The text will flow from top to bottom.
+    /// The text will move from top to bottom.
     /// </summary>
     Down,
 }

--- a/components/MarqueeText/src/MarqueeText.Events.cs
+++ b/components/MarqueeText/src/MarqueeText.Events.cs
@@ -50,8 +50,11 @@ public partial class MarqueeText
         UpdateClipping();
 
         // Update the animation when the size changes
-        UpdateAnimationProperties();
-        ResumeAnimation(true);
+        // Unless in cycling mode where the container size doesn't affect the animation.
+        if (!IsCycling)
+        {
+            UpdateAnimation(true);
+        }
     }
 
     private void StoryBoard_Completed(object? sender, object e)
@@ -60,6 +63,9 @@ public partial class MarqueeText
         MarqueeCompleted?.Invoke(this, EventArgs.Empty);
 
         // Update the secondary text to match the new text
-        SecondaryText = Text;
+        if (IsCycling)
+        {
+            SecondaryText = Text;
+        }
     }
 }

--- a/components/MarqueeText/src/MarqueeText.Events.cs
+++ b/components/MarqueeText/src/MarqueeText.Events.cs
@@ -52,13 +52,23 @@ public partial class MarqueeText
             Rect = new Rect(0, 0, e.NewSize.Width, e.NewSize.Height)
         };
 
-        // The marquee should run when the size changes in case the text gets cutoff
-        StartMarquee();
+        // Update the animation when the size changes
+        // Unless in cycling mode where the container size doesn't affect the animation.
+        if (!IsCycling)
+        {
+            UpdateAnimation(true);
+        }
     }
 
     private void StoryBoard_Completed(object? sender, object e)
     {
         StopMarquee(true);
         MarqueeCompleted?.Invoke(this, EventArgs.Empty);
+
+        // Update the secondary text to match the new text
+        if (IsCycling)
+        {
+            SecondaryText = Text;
+        }
     }
 }

--- a/components/MarqueeText/src/MarqueeText.Events.cs
+++ b/components/MarqueeText/src/MarqueeText.Events.cs
@@ -50,8 +50,8 @@ public partial class MarqueeText
         UpdateClipping();
 
         // Update the animation when the size changes
-        // Unless in cycling mode where the container size doesn't affect the animation.
-        if (!IsCycling)
+        // Unless in transition mode where the container size doesn't affect the animation.
+        if (!IsTransition)
         {
             UpdateAnimation(true);
         }
@@ -63,7 +63,7 @@ public partial class MarqueeText
         MarqueeCompleted?.Invoke(this, EventArgs.Empty);
 
         // Update the secondary text to match the new text
-        if (IsCycling)
+        if (IsTransition)
         {
             SecondaryText = Text;
         }

--- a/components/MarqueeText/src/MarqueeText.Events.cs
+++ b/components/MarqueeText/src/MarqueeText.Events.cs
@@ -50,11 +50,8 @@ public partial class MarqueeText
         UpdateClipping();
 
         // Update the animation when the size changes
-        // Unless in cycling mode where the container size doesn't affect the animation.
-        if (!IsCycling)
-        {
-            UpdateAnimation(true);
-        }
+        UpdateAnimationProperties();
+        ResumeAnimation(true);
     }
 
     private void StoryBoard_Completed(object? sender, object e)
@@ -63,9 +60,6 @@ public partial class MarqueeText
         MarqueeCompleted?.Invoke(this, EventArgs.Empty);
 
         // Update the secondary text to match the new text
-        if (IsCycling)
-        {
-            SecondaryText = Text;
-        }
+        SecondaryText = Text;
     }
 }

--- a/components/MarqueeText/src/MarqueeText.Events.cs
+++ b/components/MarqueeText/src/MarqueeText.Events.cs
@@ -47,10 +47,7 @@ public partial class MarqueeText
         }
         
         // Clip the marquee within its bounds
-        _marqueeContainer.Clip = new RectangleGeometry
-        {
-            Rect = new Rect(0, 0, e.NewSize.Width, e.NewSize.Height)
-        };
+        UpdateClipping();
 
         // Update the animation when the size changes
         // Unless in cycling mode where the container size doesn't affect the animation.

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -23,20 +23,11 @@ public partial class MarqueeText
     private static readonly DependencyProperty RepeatBehaviorProperty =
         DependencyProperty.Register(nameof(RepeatBehavior), typeof(RepeatBehavior), typeof(MarqueeText), new PropertyMetadata(new RepeatBehavior(1), PropertyChanged));
 
-    private static readonly DependencyProperty StartOnTextChangedProperety =
-        DependencyProperty.Register(nameof(StartOnTextChanged), typeof(bool), typeof(MarqueeText), new PropertyMetadata(false));
+    private static readonly DependencyProperty BehaviorProperty =
+        DependencyProperty.Register(nameof(Behavior), typeof(MarqueeBehavior), typeof(MarqueeText), new PropertyMetadata(0, BehaviorPropertyChanged));
 
     private static readonly DependencyProperty DirectionProperty =
         DependencyProperty.Register(nameof(Direction), typeof(MarqueeDirection), typeof(MarqueeText), new PropertyMetadata(MarqueeDirection.Left, DirectionPropertyChanged));
-
-    private static readonly DependencyProperty TickerStartPositionProperty =
-        DependencyProperty.Register(nameof(TickerStartPosition), typeof(double), typeof(MarqueeText), new PropertyMetadata(0));
-
-    private static readonly DependencyProperty TickerEndPositionProperty =
-        DependencyProperty.Register(nameof(TickerEndPosition), typeof(double), typeof(MarqueeText), new PropertyMetadata(0));
-
-    private static readonly DependencyProperty TickerAnimationDurationProperty =
-        DependencyProperty.Register(nameof(TickerAnimationDuration), typeof(TimeSpan), typeof(MarqueeText), new PropertyMetadata(TimeSpan.Zero));
 
     #if !HAS_UNO
     private static readonly DependencyProperty TextDecorationsProperty =
@@ -55,9 +46,6 @@ public partial class MarqueeText
     /// <summary>
     /// Gets a secondary text field used for binding the secondary text block.
     /// </summary>
-    /// <remarks>
-    /// When the <see cref="TextProperty"/> is updated, this 
-    /// </remarks>
     public string SecondaryText
     {
         get => (string)GetValue(SecondaryTextProperty);
@@ -77,27 +65,40 @@ public partial class MarqueeText
     }
 
     /// <summary>
-    /// Gets or sets whether or not the animation begin when the <see cref="TextProperty"/> is updated.
-    /// </summary>
-    public bool StartOnTextChanged
-    {
-        get => (bool)GetValue(StartOnTextChangedProperety);
-        set => SetValue(StartOnTextChangedProperety, value);
-    }
-
-    /// <summary>
-    /// Gets or sets whether or not to ignore if the text fits when running the animation.
-    /// </summary>
-    public bool IgnoreFitting => true;
-
-    /// <summary>
     /// Gets or sets a value indicating whether or not the marquee scroll repeats.
     /// </summary>
+    /// <remarks>
+    /// Ignored if the behavior is <see cref="MarqueeBehavior.Cycle"/>
+    /// </remarks>
     public RepeatBehavior RepeatBehavior
     {
         get => (RepeatBehavior)GetValue(RepeatBehaviorProperty);
         set => SetValue(RepeatBehaviorProperty, value);
     }
+
+    /// <summary>
+    /// Gets or sets the marquee behavior.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="MarqueeBehavior.Looping"/> the text won't scroll if the text can already fit in the screen.
+    /// </remarks>
+    public MarqueeBehavior Behavior
+    {
+        get => (MarqueeBehavior)GetValue(BehaviorProperty);
+        set => SetValue(BehaviorProperty, value);
+    }
+
+    private bool IsTicker => Behavior == MarqueeBehavior.Ticker;
+
+    private bool IsLooping => Behavior == MarqueeBehavior.Looping;
+
+#if !HAS_UNO
+    private bool IsBouncing => Behavior == MarqueeBehavior.Bouncing;
+#else
+    private bool IsBouncing => false;
+#endif
+
+    private bool IsCycling => Behavior == MarqueeBehavior.Cycle;
 
     /// <summary>
     /// Gets or sets the direction the Marquee should scroll
@@ -107,29 +108,6 @@ public partial class MarqueeText
         get => (MarqueeDirection)GetValue(DirectionProperty);
         set => SetValue(DirectionProperty, value);
     }
-
-    public double TickerStartPosition
-    {
-        get => (double)GetValue(TickerStartPositionProperty);
-        set => SetValue(TickerStartPositionProperty, value);
-    }
-
-    public double TickerEndPosition
-    {
-        get => (double)GetValue(TickerEndPositionProperty);
-        set => SetValue(TickerEndPositionProperty, value);
-    }
-
-    public TimeSpan TickerAnimationDuration
-    {
-        get => (TimeSpan)GetValue(TickerAnimationDurationProperty);
-        set => SetValue(TickerAnimationDurationProperty, value);
-    }
-
-    /// <summary>
-    /// Gets whether or not the marquee animation is playing.
-    /// </summary>
-    public bool IsRunning => _isActive;
 
     private bool IsDirectionHorizontal => Direction is MarqueeDirection.Left or MarqueeDirection.Right;
 
@@ -158,6 +136,7 @@ public partial class MarqueeText
         var newBehavior = (MarqueeBehavior)e.NewValue;
         
         control.UpdateClipping();
+        VisualStateManager.GoToState(control, GetVisualStateName(newBehavior), true);
 
         control.StopMarquee(false);
         if (active)
@@ -178,8 +157,11 @@ public partial class MarqueeText
         var newDirection = (MarqueeDirection)e.NewValue;
         bool oldAxisX = oldDirection is MarqueeDirection.Left or MarqueeDirection.Right;
         bool newAxisX = newDirection is MarqueeDirection.Left or MarqueeDirection.Right;
-        
-        control.StopMarquee(false);
+
+        if (control.IsCycling || oldAxisX != newAxisX)
+        {
+            control.StopMarquee(false);
+        }
 
         VisualStateManager.GoToState(control, GetVisualStateName(newDirection), true);
 
@@ -196,14 +178,17 @@ public partial class MarqueeText
             return;
         }
 
-        if (!control.StartOnTextChanged)
+        // If the mode is not cycling, update the secondary text to match and handle with standard property changed.
+        if (!control.IsCycling)
         {
+            control.SecondaryText = (string)e.NewValue;
             PropertyChanged(d, e);
             return;
         }
-        
+
         if (!control._isActive)
         {
+            // If the mode is cycling, start the marquee.
             // We can skip this if the animation is already
             // playing because that's smoother than starting a new animation.
             control.StartMarquee();
@@ -217,19 +202,6 @@ public partial class MarqueeText
             return;
         }
 
-        control.UpdateAnimationProperties();
-        control.ResumeAnimation();
-    }
-
-    private void UpdateAnimationProperties()
-    {
-        if (_marqueeContainer is null || _segment1 is null)
-        {
-            return;
-        }
-
-        TickerStartPosition = IsDirectionHorizontal ? _marqueeContainer.ActualWidth : _marqueeContainer.ActualHeight;
-        TickerEndPosition = IsDirectionHorizontal ? -_segment1.ActualWidth : -_segment1.ActualHeight;
-        TickerAnimationDuration = TimeSpan.FromSeconds(Math.Abs(TickerStartPosition - TickerEndPosition) / Speed);
+        control.UpdateAnimation();
     }
 }

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -197,8 +197,13 @@ public partial class MarqueeText
             return;
         }
 
-        // If the mode is cycling, start the marquee.
-        control.StartMarquee();
+        if (!control._isActive)
+        {
+            // If the mode is cycling, start the marquee.
+            // We can skip this if the animation is already
+            // playing because that's smoother than starting a new animation.
+            control.StartMarquee();
+        }
     }
 
     private static void PropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -134,7 +134,8 @@ public partial class MarqueeText
 
         bool active = control._isActive;
         var newBehavior = (MarqueeBehavior)e.NewValue;
-
+        
+        control.UpdateClipping();
         VisualStateManager.GoToState(control, GetVisualStateName(newBehavior), true);
 
         control.StopMarquee(false);

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -29,9 +29,6 @@ public partial class MarqueeText
     private static readonly DependencyProperty DirectionProperty =
         DependencyProperty.Register(nameof(Direction), typeof(MarqueeDirection), typeof(MarqueeText), new PropertyMetadata(MarqueeDirection.Left, DirectionPropertyChanged));
 
-    private static readonly DependencyProperty RepeatQueueProperty =
-        DependencyProperty.Register(nameof(RepeatQueue), typeof(bool), typeof(MarqueeText), new PropertyMetadata(false));
-
     #if !HAS_UNO
     private static readonly DependencyProperty TextDecorationsProperty =
         DependencyProperty.Register(nameof(TextDecorations), typeof(TextDecorations), typeof(MarqueeText), new PropertyMetadata(TextDecorations.None));
@@ -115,15 +112,6 @@ public partial class MarqueeText
     private bool IsDirectionHorizontal => Direction is MarqueeDirection.Left or MarqueeDirection.Right;
 
     private bool IsDirectionInverse => Direction is MarqueeDirection.Down or MarqueeDirection.Right;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether or not messages in the <see cref="Texts"/> queue repeat.
-    /// </summary>
-    public bool RepeatQueue
-    {
-        get => (bool)GetValue(RepeatQueueProperty);
-        set => SetValue(RepeatQueueProperty, value);
-    }
 
     // Waiting on https://github.com/unoplatform/uno/issues/12929
     #if !HAS_UNO

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -56,7 +56,7 @@ public partial class MarqueeText
     /// Gets or sets the speed the text moves in the Marquee.
     /// </summary>
     /// <remarks>
-    /// Ignored if the behavior is <see cref="MarqueeBehavior.Cycle"/>
+    /// Ignored if the behavior is <see cref="MarqueeBehavior.Transition"/>
     /// </remarks>
     public double Speed
     {
@@ -68,7 +68,7 @@ public partial class MarqueeText
     /// Gets or sets a value indicating whether or not the marquee scroll repeats.
     /// </summary>
     /// <remarks>
-    /// Ignored if the behavior is <see cref="MarqueeBehavior.Cycle"/>
+    /// Ignored if the behavior is <see cref="MarqueeBehavior.Transition"/>
     /// </remarks>
     public RepeatBehavior RepeatBehavior
     {
@@ -98,7 +98,7 @@ public partial class MarqueeText
     private bool IsBouncing => false;
 #endif
 
-    private bool IsCycling => Behavior == MarqueeBehavior.Cycle;
+    private bool IsTransition => Behavior == MarqueeBehavior.Transition;
 
     /// <summary>
     /// Gets or sets the direction the Marquee should scroll
@@ -158,7 +158,7 @@ public partial class MarqueeText
         bool oldAxisX = oldDirection is MarqueeDirection.Left or MarqueeDirection.Right;
         bool newAxisX = newDirection is MarqueeDirection.Left or MarqueeDirection.Right;
 
-        if (control.IsCycling || oldAxisX != newAxisX)
+        if (control.IsTransition || oldAxisX != newAxisX)
         {
             control.StopMarquee(false);
         }
@@ -178,8 +178,8 @@ public partial class MarqueeText
             return;
         }
 
-        // If the mode is not cycling, update the secondary text to match and handle with standard property changed.
-        if (!control.IsCycling)
+        // If the mode is not transition, update the secondary text to match and handle with standard property changed.
+        if (!control.IsTransition)
         {
             control.SecondaryText = (string)e.NewValue;
             PropertyChanged(d, e);
@@ -188,7 +188,7 @@ public partial class MarqueeText
 
         if (!control._isActive)
         {
-            // If the mode is cycling, start the marquee.
+            // If the mode is transition, start the marquee.
             // We can skip this if the animation is already
             // playing because that's smoother than starting a new animation.
             control.StartMarquee();

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -26,6 +26,9 @@ public partial class MarqueeText
     private static readonly DependencyProperty DirectionProperty =
         DependencyProperty.Register(nameof(Direction), typeof(MarqueeDirection), typeof(MarqueeText), new PropertyMetadata(MarqueeDirection.Left, DirectionPropertyChanged));
 
+    private static readonly DependencyProperty RepeatQueueProperty =
+        DependencyProperty.Register(nameof(RepeatQueue), typeof(bool), typeof(MarqueeText), new PropertyMetadata(false));
+
     #if !HAS_UNO
     private static readonly DependencyProperty TextDecorationsProperty =
         DependencyProperty.Register(nameof(TextDecorations), typeof(TextDecorations), typeof(MarqueeText), new PropertyMetadata(TextDecorations.None));
@@ -41,6 +44,11 @@ public partial class MarqueeText
     }
 
     /// <summary>
+    /// Gets or sets the texts queue to be displayed in the Marquee.
+    /// </summary>
+    public Queue<string>? Texts { get; set; }
+
+    /// <summary>
     /// Gets or sets the speed the text moves in the Marquee.
     /// </summary>
     public double Speed
@@ -52,6 +60,9 @@ public partial class MarqueeText
     /// <summary>
     /// Gets or sets a value indicating whether or not the marquee scroll repeats.
     /// </summary>
+    /// <remarks>
+    /// Ignored if the behavior is <see cref="MarqueeBehavior.Cycle"/>
+    /// </remarks>
     public RepeatBehavior RepeatBehavior
     {
         get => (RepeatBehavior)GetValue(RepeatBehaviorProperty);
@@ -61,6 +72,9 @@ public partial class MarqueeText
     /// <summary>
     /// Gets or sets the marquee behavior.
     /// </summary>
+    /// <remarks>
+    /// When <see cref="MarqueeBehavior.Looping"/> the text won't scroll if the text can already fit in the screen.
+    /// </remarks>
     public MarqueeBehavior Behavior
     {
         get => (MarqueeBehavior)GetValue(BehaviorProperty);
@@ -77,12 +91,11 @@ public partial class MarqueeText
     private bool IsBouncing => false;
 #endif
 
+    private bool IsCycling => Behavior == MarqueeBehavior.Cycle;
+
     /// <summary>
-    /// Gets or sets a value indicating whether or not the marquee text wraps.
+    /// Gets or sets the direction the Marquee should scroll
     /// </summary>
-    /// <remarks>
-    /// Wrapping text won't scroll if the text can already fit in the screen.
-    /// </remarks>
     public MarqueeDirection Direction
     {
         get => (MarqueeDirection)GetValue(DirectionProperty);
@@ -91,7 +104,16 @@ public partial class MarqueeText
 
     private bool IsDirectionHorizontal => Direction is MarqueeDirection.Left or MarqueeDirection.Right;
 
-    private bool IsDirectionInverse => Direction is MarqueeDirection.Up or MarqueeDirection.Right;
+    private bool IsDirectionInverse => Direction is MarqueeDirection.Down or MarqueeDirection.Right;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not messages in the <see cref="Texts"/> queue repeat.
+    /// </summary>
+    public bool RepeatQueue
+    {
+        get => (bool)GetValue(RepeatQueueProperty);
+        set => SetValue(RepeatQueueProperty, value);
+    }
 
     // Waiting on https://github.com/unoplatform/uno/issues/12929
     #if !HAS_UNO

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -169,7 +169,7 @@ public partial class MarqueeText
         bool oldAxisX = oldDirection is MarqueeDirection.Left or MarqueeDirection.Right;
         bool newAxisX = newDirection is MarqueeDirection.Left or MarqueeDirection.Right;
 
-        if (oldAxisX != newAxisX)
+        if (control.IsCycling || oldAxisX != newAxisX)
         {
             control.StopMarquee(false);
         }
@@ -197,6 +197,7 @@ public partial class MarqueeText
             return;
         }
 
+        // If the mode is cycling, start the marquee.
         control.StartMarquee();
     }
 

--- a/components/MarqueeText/src/MarqueeText.Properties.cs
+++ b/components/MarqueeText/src/MarqueeText.Properties.cs
@@ -51,6 +51,9 @@ public partial class MarqueeText
     /// <summary>
     /// Gets or sets the speed the text moves in the Marquee.
     /// </summary>
+    /// <remarks>
+    /// Ignored if the behavior is <see cref="MarqueeBehavior.Cycle"/>
+    /// </remarks>
     public double Speed
     {
         get => (double)GetValue(SpeedProperty);
@@ -96,6 +99,9 @@ public partial class MarqueeText
     /// <summary>
     /// Gets or sets the direction the Marquee should scroll
     /// </summary>
+    /// <remarks>
+    /// Ignored if the behavior is <see cref="MarqueeBehavior.Cycle"/>
+    /// </remarks>
     public MarqueeDirection Direction
     {
         get => (MarqueeDirection)GetValue(DirectionProperty);

--- a/components/MarqueeText/src/MarqueeText.cs
+++ b/components/MarqueeText/src/MarqueeText.cs
@@ -180,6 +180,7 @@ public partial class MarqueeText : Control
         // Update the animation to the stopped position.
         if (!_isActive)
         {
+            _marqueeStoryboard?.Stop();
             VisualStateManager.GoToState(this, MarqueeStoppedState, false);
 
             return false;
@@ -269,16 +270,14 @@ public partial class MarqueeText : Control
         // Calculate the animation duration by dividing the distance by the speed
         TimeSpan duration = TimeSpan.FromSeconds(distance / Speed);
 
-        // Set the delay (only relevent in cycling mode)
-        TimeSpan delay = IsCycling ? TimeSpan.FromSeconds(3) : TimeSpan.Zero;
-
         // The second segment of text should be hidden if the marquee is not in looping mode
         _segment2.Visibility = IsLooping ? Visibility.Visible : Visibility.Collapsed;
-
-        // Unbind events from the old storyboard
+        
+        // Unbind events from the old storyboard and stop it before disposal.
         if (_marqueeStoryboard is not null)
         {
             _marqueeStoryboard.Completed -= StoryBoard_Completed;
+            _marqueeStoryboard?.Stop();
         }
 
         // Create new storyboard and animation
@@ -290,7 +289,7 @@ public partial class MarqueeText : Control
 
         // Bind the storyboard completed event
         _marqueeStoryboard.Completed += StoryBoard_Completed;
-
+        
         // Set the visual state to active and begin the animation
         VisualStateManager.GoToState(this, MarqueeActiveState, true);
         _marqueeStoryboard.Begin();

--- a/components/MarqueeText/src/MarqueeText.cs
+++ b/components/MarqueeText/src/MarqueeText.cs
@@ -221,7 +221,6 @@ public partial class MarqueeText : Control
             // calling update animation. If _isActive were passed, it would allow for
             // MarqueeStopped to be invoked when the marquee was already stopped.
             StopMarquee(resume);
-            _segment2.Visibility = Visibility.Collapsed;
             
             return false;
         }

--- a/components/MarqueeText/src/MarqueeText.cs
+++ b/components/MarqueeText/src/MarqueeText.cs
@@ -55,7 +55,7 @@ public partial class MarqueeText : Control
     private Panel? _marqueeContainer;
     private FrameworkElement? _segment1;
     private FrameworkElement? _segment2;
-    private TranslateTransform? _marqueeTransform;
+    private CompositeTransform? _marqueeTransform;
     private Storyboard? _cyclingStoryboard;
     private Storyboard? _marqueeStoryboard;
 
@@ -78,7 +78,7 @@ public partial class MarqueeText : Control
         _marqueeContainer = (Panel)GetTemplateChild(MarqueeContainerPartName);
         _segment1 = (FrameworkElement)GetTemplateChild(Segment1PartName);
         _segment2 = (FrameworkElement)GetTemplateChild(Segment2PartName);
-        _marqueeTransform = (TranslateTransform)GetTemplateChild(MarqueeTransformPartName);
+        _marqueeTransform = (CompositeTransform)GetTemplateChild(MarqueeTransformPartName);
         _cyclingStoryboard = (Storyboard)GetTemplateChild(CyclingAnaimationPartName);
 
         _marqueeContainer.SizeChanged += Container_SizeChanged;
@@ -90,6 +90,7 @@ public partial class MarqueeText : Control
 
         VisualStateManager.GoToState(this, GetVisualStateName(Direction), false);
         VisualStateManager.GoToState(this, GetVisualStateName(Behavior), false);
+        StopMarquee();
     }
 
     private static string GetVisualStateName(MarqueeDirection direction)
@@ -199,8 +200,8 @@ public partial class MarqueeText : Control
             // are defined by width and X coordinates.
             containerSize = _marqueeContainer.ActualWidth;
             segmentSize = _segment1.ActualWidth;
-            value = _marqueeTransform.X;
-            targetProperty = "(TranslateTransform.X)";
+            value = _marqueeTransform.TranslateX;
+            targetProperty = "(CompositeTransform.TranslateX)";
         }
         else
         {
@@ -208,8 +209,8 @@ public partial class MarqueeText : Control
             // are defined by height and Y coordinates.
             containerSize = _marqueeContainer.ActualHeight;
             segmentSize = _segment1.ActualHeight;
-            value = _marqueeTransform.Y;
-            targetProperty = "(TranslateTransform.Y)";
+            value = _marqueeTransform.TranslateY;
+            targetProperty = "(CompositeTransform.TranslateY)";
         }
 
         if (IsLooping && segmentSize < containerSize)
@@ -352,6 +353,25 @@ public partial class MarqueeText : Control
         marqueeStoryboard.Children.Add(posAnim);
 
         return marqueeStoryboard;
+    }
+
+    private void UpdateClipping()
+    {
+        if (_marqueeContainer is null)
+        {
+            return;
+        }
+
+        _marqueeContainer.Clip = new RectangleGeometry
+        {
+            Rect = new Rect(0, 0, ActualWidth, ActualHeight)
+        };
+
+        if (IsCycling)
+        {
+            // Don't clip in cycling mode
+            _marqueeContainer.Clip = null;
+        }
     }
 }
 

--- a/components/MarqueeText/src/MarqueeText.cs
+++ b/components/MarqueeText/src/MarqueeText.cs
@@ -50,8 +50,6 @@ public partial class MarqueeText : Control
     private const string BouncingVisualStateName = "Bouncing";
     private const string CycleVisualStateName = "Cycle";
 
-    private const double CycleDistance = 20d;
-
     private Panel? _marqueeContainer;
     private FrameworkElement? _segment1;
     private FrameworkElement? _segment2;
@@ -232,8 +230,8 @@ public partial class MarqueeText : Control
 
         double end = Behavior switch
         {
-            // Offset by cycle distance pixels
-            MarqueeBehavior.Cycle => CycleDistance,
+            // (this value just needs to be non-Zero, the real number is handled in the Style)
+            MarqueeBehavior.Cycle => 20,
 #if !HAS_UNO
             // When the end of the text reaches the border if in bouncing mode
             MarqueeBehavior.Bouncing => containerSize - segmentSize,
@@ -245,16 +243,8 @@ public partial class MarqueeText : Control
         // Swap the directions if inverse direction animation
         if (IsDirectionInverse)
         {
-            if (IsCycling)
-            {
-                // Swap the offset of the cycle
-                end = -end;
-            }
-            else
-            {
-                // Swap the start and end to inverse direction for right or upwards
-                (start, end) = (end, start);
-            }
+            // Swap the start and end to inverse direction for right or upwards
+            (start, end) = (end, start);
         }
 
         // The distance is used for calculating the duration and the previous
@@ -269,9 +259,6 @@ public partial class MarqueeText : Control
 
         // Calculate the animation duration by dividing the distance by the speed
         TimeSpan duration = TimeSpan.FromSeconds(distance / Speed);
-
-        // The second segment of text should be hidden if the marquee is not in looping mode
-        _segment2.Visibility = IsLooping ? Visibility.Visible : Visibility.Collapsed;
         
         // Unbind events from the old storyboard and stop it before disposal.
         if (_marqueeStoryboard is not null)
@@ -308,7 +295,7 @@ public partial class MarqueeText : Control
     /// This is method is used for all modes except cycling.
     /// </remarks>
     private Storyboard CreateMarqueeStoryboardAnimation(double start, double end, TimeSpan duration, string targetProperty)
-    {   
+    {
         // Initialize the new storyboard
         var marqueeStoryboard = new Storyboard
         {

--- a/components/MarqueeText/src/MarqueeText.cs
+++ b/components/MarqueeText/src/MarqueeText.cs
@@ -9,18 +9,13 @@ namespace CommunityToolkit.Labs.WinUI.MarqueeTextRns;
 /// </summary>
 [TemplatePart(Name = MarqueeContainerPartName, Type = typeof(Panel))]
 [TemplatePart(Name = Segment1PartName, Type = typeof(FrameworkTemplate))]
-[TemplatePart(Name = Segment2PartName, Type = typeof(FrameworkTemplate))]
-[TemplatePart(Name = Segment2PartName, Type = typeof(FrameworkTemplate))]
 [TemplatePart(Name = MarqueeTransformPartName, Type = typeof(TranslateTransform))]
-[TemplatePart(Name = CyclingAnaimationPartName, Type = typeof(Storyboard))]
+[TemplatePart(Name = MarqueeAnimationPartName, Type = typeof(Storyboard))]
+[TemplatePart(Name = TranslationAnimationPartName, Type = typeof(Storyboard))]
 [TemplateVisualState(GroupName = DirectionVisualStateGroupName, Name = LeftwardsVisualStateName)]
 [TemplateVisualState(GroupName = DirectionVisualStateGroupName, Name = RightwardsVisualStateName)]
 [TemplateVisualState(GroupName = DirectionVisualStateGroupName, Name = UpwardsVisualStateName)]
 [TemplateVisualState(GroupName = DirectionVisualStateGroupName, Name = DownwardsVisualStateName)]
-[TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = TickerVisualStateName)]
-[TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = LoopingVisualStateName)]
-[TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = BouncingVisualStateName)]
-[TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = CycleVisualStateName)]
 [ContentProperty(Name = nameof(Text))]
 
 #if HAS_UNO
@@ -31,9 +26,9 @@ public partial class MarqueeText : Control
 {
     private const string MarqueeContainerPartName = "MarqueeContainer";
     private const string Segment1PartName = "Segment1";
-    private const string Segment2PartName = "Segment2";
     private const string MarqueeTransformPartName = "MarqueeTransform";
-    private const string CyclingAnaimationPartName = "CyclingAnimation";
+    private const string MarqueeAnimationPartName = "MarqueeAnimation";
+    private const string TranslationAnimationPartName = "TranslationAnimation";
 
     private const string MarqueeActiveState = "MarqueeActive";
     private const string MarqueeStoppedState = "MarqueeStopped";
@@ -44,18 +39,11 @@ public partial class MarqueeText : Control
     private const string UpwardsVisualStateName = "Upwards";
     private const string DownwardsVisualStateName = "Downwards";
 
-    private const string BehaviorVisualStateGroupName = "BehaviorStateGroup";
-    private const string TickerVisualStateName = "Ticker";
-    private const string LoopingVisualStateName = "Looping";
-    private const string BouncingVisualStateName = "Bouncing";
-    private const string CycleVisualStateName = "Cycle";
-
     private Panel? _marqueeContainer;
     private FrameworkElement? _segment1;
-    private FrameworkElement? _segment2;
     private CompositeTransform? _marqueeTransform;
-    private Storyboard? _cyclingStoryboard;
     private Storyboard? _marqueeStoryboard;
+    private DoubleAnimation? _translationAnimation;
 
     private bool _isActive;
 
@@ -75,9 +63,9 @@ public partial class MarqueeText : Control
         // Explicit casting throws early when parts are missing from the template
         _marqueeContainer = (Panel)GetTemplateChild(MarqueeContainerPartName);
         _segment1 = (FrameworkElement)GetTemplateChild(Segment1PartName);
-        _segment2 = (FrameworkElement)GetTemplateChild(Segment2PartName);
         _marqueeTransform = (CompositeTransform)GetTemplateChild(MarqueeTransformPartName);
-        _cyclingStoryboard = (Storyboard)GetTemplateChild(CyclingAnaimationPartName);
+        _marqueeStoryboard = (Storyboard)GetTemplateChild(MarqueeAnimationPartName);
+        _translationAnimation = (DoubleAnimation)GetTemplateChild(TranslationAnimationPartName);
 
         _marqueeContainer.SizeChanged += Container_SizeChanged;
 
@@ -87,7 +75,8 @@ public partial class MarqueeText : Control
         //Unloaded += MarqueeText_Unloaded;
 
         VisualStateManager.GoToState(this, GetVisualStateName(Direction), false);
-        VisualStateManager.GoToState(this, GetVisualStateName(Behavior), false);
+
+        UpdateAnimationProperties();
         StopMarquee();
     }
 
@@ -103,19 +92,6 @@ public partial class MarqueeText : Control
         };
     }
 
-    private static string GetVisualStateName(MarqueeBehavior behavior)
-    {
-        return behavior switch
-        {
-            MarqueeBehavior.Ticker => TickerVisualStateName,
-            MarqueeBehavior.Looping => LoopingVisualStateName,
-#if !HAS_UNO
-            MarqueeBehavior.Bouncing => BouncingVisualStateName,
-#endif
-            _ => TickerVisualStateName,
-        };
-    }
-
     /// <summary>
     /// Begins the Marquee animation if not running.
     /// </summary>
@@ -124,7 +100,7 @@ public partial class MarqueeText : Control
     {
         bool initial = _isActive;
         _isActive = true;
-        bool playing = UpdateAnimation(initial);
+        bool playing = ResumeAnimation(initial);
 
         // Invoke MarqueeBegan if Marquee is now playing and was not before
         if (playing && !initial)
@@ -146,7 +122,7 @@ public partial class MarqueeText : Control
     {
         // Set _isActive and update the animation to match
         _isActive = false;
-        bool playing = UpdateAnimation(false);
+        bool playing = ResumeAnimation(false);
 
         // Invoke MarqueeStopped if Marquee is not playing and was before
         if (!playing && initialState)
@@ -161,7 +137,7 @@ public partial class MarqueeText : Control
     /// <param name="resume">True if animation should resume from its current position, false if it should restart.</param>
     /// <exception cref="InvalidOperationException">Thrown when template parts are not supplied.</exception>
     /// <returns>True if the Animation is now playing.</returns>
-    private bool UpdateAnimation(bool resume = true)
+    private bool ResumeAnimation(bool resume = true)
     {
         // Crucial template parts are missing!
         // This can happen during initialization of certain properties.
@@ -169,8 +145,7 @@ public partial class MarqueeText : Control
         if (_marqueeContainer is null ||
             _marqueeTransform is null ||
             _segment1 is null ||
-            _segment2 is null ||
-            _cyclingStoryboard is null)
+            _marqueeStoryboard is null)
         {
             return false;
         }
@@ -179,7 +154,7 @@ public partial class MarqueeText : Control
         // Update the animation to the stopped position.
         if (!_isActive)
         {
-            _marqueeStoryboard?.Stop();
+            _marqueeStoryboard.Stop();
             VisualStateManager.GoToState(this, MarqueeStoppedState, false);
 
             return false;
@@ -190,7 +165,6 @@ public partial class MarqueeText : Control
         double containerSize;
         double segmentSize;
         double value;
-        string targetProperty;
 
         if (IsDirectionHorizontal)
         {
@@ -199,7 +173,6 @@ public partial class MarqueeText : Control
             containerSize = _marqueeContainer.ActualWidth;
             segmentSize = _segment1.ActualWidth;
             value = _marqueeTransform.TranslateX;
-            targetProperty = "(CompositeTransform.TranslateX)";
         }
         else
         {
@@ -208,10 +181,9 @@ public partial class MarqueeText : Control
             containerSize = _marqueeContainer.ActualHeight;
             segmentSize = _segment1.ActualHeight;
             value = _marqueeTransform.TranslateY;
-            targetProperty = "(CompositeTransform.TranslateY)";
         }
 
-        if (IsLooping && segmentSize < containerSize)
+        if (!IgnoreFitting && segmentSize < containerSize)
         {
             // If the marquee is in looping mode and the segment is smaller
             // than the container, then the animation does not not need to play.
@@ -223,56 +195,8 @@ public partial class MarqueeText : Control
             
             return false;
         }
-
-        // The start position is offset 100% if in ticker mode
-        // Otherwise it's 0
-        double start = IsTicker ? containerSize : 0;
-
-        double end = Behavior switch
-        {
-            // (this value just needs to be non-Zero, the real number is handled in the Style)
-            MarqueeBehavior.Cycle => 20,
-#if !HAS_UNO
-            // When the end of the text reaches the border if in bouncing mode
-            MarqueeBehavior.Bouncing => containerSize - segmentSize,
-#endif
-            // When the first set of text is 100% out of view
-            MarqueeBehavior.Ticker or MarqueeBehavior.Looping or _ => -segmentSize,
-        };
-
-        // Swap the directions if inverse direction animation
-        if (IsDirectionInverse)
-        {
-            // Swap the start and end to inverse direction for right or upwards
-            (start, end) = (end, start);
-        }
-
-        // The distance is used for calculating the duration and the previous
-        // animation progress if resuming
-        double distance = Math.Abs(start - end);
-
-        // If the distance is zero, don't play an animation
-        if (distance is 0)
-        {
-            return false;
-        }
-
-        // Calculate the animation duration by dividing the distance by the speed
-        TimeSpan duration = TimeSpan.FromSeconds(distance / Speed);
         
-        // Unbind events from the old storyboard and stop it before disposal.
-        if (_marqueeStoryboard is not null)
-        {
-            _marqueeStoryboard.Completed -= StoryBoard_Completed;
-            _marqueeStoryboard?.Stop();
-        }
-
-        // Create new storyboard and animation
-        _marqueeStoryboard = Behavior switch
-        {
-            MarqueeBehavior.Cycle => _cyclingStoryboard,
-            _ => CreateMarqueeStoryboardAnimation(start, end, duration, targetProperty),
-        };
+        _marqueeStoryboard.Stop();
 
         // Bind the storyboard completed event
         _marqueeStoryboard.Completed += StoryBoard_Completed;
@@ -280,66 +204,20 @@ public partial class MarqueeText : Control
         // Set the visual state to active and begin the animation
         VisualStateManager.GoToState(this, MarqueeActiveState, true);
         _marqueeStoryboard.Begin();
-        
+
         // If resuming, seek the animation so the text resumes from its current position.
-        if (resume)
+        if (resume && _translationAnimation is not null)
         {
+            double start = _translationAnimation.From ?? 0;
+            double end = _translationAnimation.To ?? 0;
+            double distance = start - end;
+            TimeSpan duration = _translationAnimation.Duration.TimeSpan;
+
             double progress = Math.Abs(start - value) / distance;
             _marqueeStoryboard.Seek(TimeSpan.FromTicks((long)(duration.Ticks * progress)));
         }
 
         return true;
-    }
-
-    /// <remarks>
-    /// This is method is used for all modes except cycling.
-    /// </remarks>
-    private Storyboard CreateMarqueeStoryboardAnimation(double start, double end, TimeSpan duration, string targetProperty)
-    {
-        // Initialize the new storyboard
-        var marqueeStoryboard = new Storyboard
-        {
-            Duration = duration,
-            RepeatBehavior = RepeatBehavior,
-#if !HAS_UNO
-            AutoReverse = IsBouncing,
-#endif
-        };
-        
-        // Create a new double animation, moving from [start] to [end] positions in [duration] time.
-        var posAnim = new DoubleAnimationUsingKeyFrames
-        {
-            Duration = duration,
-            RepeatBehavior = RepeatBehavior,
-#if !HAS_UNO
-            AutoReverse = IsBouncing,
-#endif
-        };
-        
-        // Set the animation target and target property
-        Storyboard.SetTarget(posAnim, _marqueeTransform);
-        Storyboard.SetTargetProperty(posAnim, targetProperty);
-
-        // Create the key frames
-        var posFrame0 = new LinearDoubleKeyFrame
-        {
-            KeyTime = KeyTime.FromTimeSpan(TimeSpan.Zero),
-            Value = start,
-        };
-        var posFrame1 = new LinearDoubleKeyFrame
-        {
-            KeyTime = KeyTime.FromTimeSpan(duration),
-            Value = end,
-        };
-
-        // Add the key frames to the animation
-        posAnim.KeyFrames.Add(posFrame0);
-        posAnim.KeyFrames.Add(posFrame1);
-
-        // Add the double animation to the storyboard
-        marqueeStoryboard.Children.Add(posAnim);
-
-        return marqueeStoryboard;
     }
 
     private void UpdateClipping()
@@ -353,12 +231,6 @@ public partial class MarqueeText : Control
         {
             Rect = new Rect(0, 0, ActualWidth, ActualHeight)
         };
-
-        if (IsCycling)
-        {
-            // Don't clip in cycling mode
-            _marqueeContainer.Clip = null;
-        }
     }
 }
 

--- a/components/MarqueeText/src/MarqueeText.cs
+++ b/components/MarqueeText/src/MarqueeText.cs
@@ -12,7 +12,7 @@ namespace CommunityToolkit.Labs.WinUI.MarqueeTextRns;
 [TemplatePart(Name = Segment2PartName, Type = typeof(FrameworkTemplate))]
 [TemplatePart(Name = Segment2PartName, Type = typeof(FrameworkTemplate))]
 [TemplatePart(Name = MarqueeTransformPartName, Type = typeof(TranslateTransform))]
-[TemplatePart(Name = CyclingAnaimationPartName, Type = typeof(Storyboard))]
+[TemplatePart(Name = TransitionAnaimationPartName, Type = typeof(Storyboard))]
 [TemplateVisualState(GroupName = DirectionVisualStateGroupName, Name = LeftwardsVisualStateName)]
 [TemplateVisualState(GroupName = DirectionVisualStateGroupName, Name = RightwardsVisualStateName)]
 [TemplateVisualState(GroupName = DirectionVisualStateGroupName, Name = UpwardsVisualStateName)]
@@ -20,7 +20,7 @@ namespace CommunityToolkit.Labs.WinUI.MarqueeTextRns;
 [TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = TickerVisualStateName)]
 [TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = LoopingVisualStateName)]
 [TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = BouncingVisualStateName)]
-[TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = CycleVisualStateName)]
+[TemplateVisualState(GroupName = BehaviorVisualStateGroupName, Name = TransitionVisualStateName)]
 [ContentProperty(Name = nameof(Text))]
 
 #if HAS_UNO
@@ -33,7 +33,7 @@ public partial class MarqueeText : Control
     private const string Segment1PartName = "Segment1";
     private const string Segment2PartName = "Segment2";
     private const string MarqueeTransformPartName = "MarqueeTransform";
-    private const string CyclingAnaimationPartName = "CyclingAnimation";
+    private const string TransitionAnaimationPartName = "TransitionAnimation";
 
     private const string MarqueeActiveState = "MarqueeActive";
     private const string MarqueeStoppedState = "MarqueeStopped";
@@ -48,13 +48,13 @@ public partial class MarqueeText : Control
     private const string TickerVisualStateName = "Ticker";
     private const string LoopingVisualStateName = "Looping";
     private const string BouncingVisualStateName = "Bouncing";
-    private const string CycleVisualStateName = "Cycle";
+    private const string TransitionVisualStateName = "Transition";
 
     private Panel? _marqueeContainer;
     private FrameworkElement? _segment1;
     private FrameworkElement? _segment2;
     private CompositeTransform? _marqueeTransform;
-    private Storyboard? _cyclingStoryboard;
+    private Storyboard? _transitionStoryboard;
     private Storyboard? _marqueeStoryboard;
 
     private bool _isActive;
@@ -77,7 +77,7 @@ public partial class MarqueeText : Control
         _segment1 = (FrameworkElement)GetTemplateChild(Segment1PartName);
         _segment2 = (FrameworkElement)GetTemplateChild(Segment2PartName);
         _marqueeTransform = (CompositeTransform)GetTemplateChild(MarqueeTransformPartName);
-        _cyclingStoryboard = (Storyboard)GetTemplateChild(CyclingAnaimationPartName);
+        _transitionStoryboard = (Storyboard)GetTemplateChild(TransitionAnaimationPartName);
 
         _marqueeContainer.SizeChanged += Container_SizeChanged;
 
@@ -170,7 +170,7 @@ public partial class MarqueeText : Control
             _marqueeTransform is null ||
             _segment1 is null ||
             _segment2 is null ||
-            _cyclingStoryboard is null)
+            _transitionStoryboard is null)
         {
             return false;
         }
@@ -231,7 +231,7 @@ public partial class MarqueeText : Control
         double end = Behavior switch
         {
             // (this value just needs to be non-Zero, the real number is handled in the Style)
-            MarqueeBehavior.Cycle => 20,
+            MarqueeBehavior.Transition => 20,
 #if !HAS_UNO
             // When the end of the text reaches the border if in bouncing mode
             MarqueeBehavior.Bouncing => containerSize - segmentSize,
@@ -270,7 +270,7 @@ public partial class MarqueeText : Control
         // Create new storyboard and animation
         _marqueeStoryboard = Behavior switch
         {
-            MarqueeBehavior.Cycle => _cyclingStoryboard,
+            MarqueeBehavior.Transition => _transitionStoryboard,
             _ => CreateMarqueeStoryboardAnimation(start, end, duration, targetProperty),
         };
 
@@ -292,7 +292,7 @@ public partial class MarqueeText : Control
     }
 
     /// <remarks>
-    /// This is method is used for all modes except cycling.
+    /// This is method is used for all modes except transition.
     /// </remarks>
     private Storyboard CreateMarqueeStoryboardAnimation(double start, double end, TimeSpan duration, string targetProperty)
     {
@@ -354,9 +354,9 @@ public partial class MarqueeText : Control
             Rect = new Rect(0, 0, ActualWidth, ActualHeight)
         };
 
-        if (IsCycling)
+        if (IsTransition)
         {
-            // Don't clip in cycling mode
+            // Don't clip in transition mode
             _marqueeContainer.Clip = null;
         }
     }

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarqueeTextRns"
@@ -61,6 +61,11 @@
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Bouncing">
+                                    <VisualState.Setters>
+                                        <Setter Target="Segment1.Padding" Value="0" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Cycle">
                                     <VisualState.Setters>
                                         <Setter Target="Segment1.Padding" Value="0" />
                                     </VisualState.Setters>

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -19,19 +19,19 @@
                           CornerRadius="{TemplateBinding CornerRadius}">
 
                         <Grid.Resources>
-                            <Storyboard x:Name="CyclingAnimation"
+                            <Storyboard x:Name="TransitionAnimation"
                                         Duration="0:0:1.2">
                                 <!--  Animate the translation  -->
-                                <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"
+                                <DoubleAnimationUsingKeyFrames x:Name="TransitionAnimationTranslationAnimation"
                                                                Storyboard.TargetName="MarqueeTransform"
                                                                Storyboard.TargetProperty="(CompositeTransform.TranslateX)"
                                                                Duration="0:0:1.2">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0"
                                                             Value="0" />
-                                    <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition"
+                                    <LinearDoubleKeyFrame x:Name="TransitionAnimationFadeOutPosition"
                                                           KeyTime="0:0:0.5"
                                                           Value="20" />
-                                    <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition"
+                                    <DiscreteDoubleKeyFrame x:Name="TransitionAnimationFadeInPosition"
                                                             KeyTime="0:0:0.7"
                                                             Value="-20" />
                                     <LinearDoubleKeyFrame KeyTime="0:0:1.2"
@@ -81,33 +81,33 @@
                                 <VisualState x:Name="Leftwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
-                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="-20" />
-                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="20" />
+                                        <Setter Target="TransitionAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
+                                        <Setter Target="TransitionAnimationFadeOutPosition.Value" Value="-20" />
+                                        <Setter Target="TransitionAnimationFadeInPosition.Value" Value="20" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Rightwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
-                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="20" />
-                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="-20" />
+                                        <Setter Target="TransitionAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
+                                        <Setter Target="TransitionAnimationFadeOutPosition.Value" Value="20" />
+                                        <Setter Target="TransitionAnimationFadeInPosition.Value" Value="-20" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Upwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
-                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="-20" />
-                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="20" />
+                                        <Setter Target="TransitionAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
+                                        <Setter Target="TransitionAnimationFadeOutPosition.Value" Value="-20" />
+                                        <Setter Target="TransitionAnimationFadeInPosition.Value" Value="20" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Downwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
-                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="20" />
-                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="-20" />
+                                        <Setter Target="TransitionAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
+                                        <Setter Target="TransitionAnimationFadeOutPosition.Value" Value="20" />
+                                        <Setter Target="TransitionAnimationFadeInPosition.Value" Value="-20" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -130,7 +130,7 @@
                                         <Setter Target="Segment2.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState x:Name="Cycle">
+                                <VisualState x:Name="Transition">
                                     <VisualState.Setters>
                                         <Setter Target="Segment1.Padding" Value="0" />
                                         <Setter Target="Segment2.Visibility" Value="Collapsed" />

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarqueeTextRns"
@@ -17,6 +17,56 @@
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           CornerRadius="{TemplateBinding CornerRadius}">
+
+                        <Grid.Resources>
+                            <Storyboard x:Name="CyclingAnimation"
+                                        Duration="0:0:1.2">
+                                <!--  Animate the translation  -->
+                                <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"
+                                                               Storyboard.TargetName="MarqueeTransform"
+                                                               Storyboard.TargetProperty="(CompositeTransform.TranslateX)"
+                                                               Duration="0:0:1.2">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0"
+                                                            Value="0" />
+                                    <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition"
+                                                          KeyTime="0:0:0.5"
+                                                          Value="20" />
+                                    <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition"
+                                                            KeyTime="0:0:0.7"
+                                                            Value="-20" />
+                                    <LinearDoubleKeyFrame KeyTime="0:0:1.2"
+                                                          Value="0" />
+                                </DoubleAnimationUsingKeyFrames>
+                                <!--  Animate the opacity  -->
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MarqueePanel"
+                                                               Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                               Duration="0:0:1.2">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0"
+                                                            Value="1" />
+                                    <LinearDoubleKeyFrame KeyTime="0:0:0.5"
+                                                          Value="0" />
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0.7"
+                                                            Value="0" />
+                                    <LinearDoubleKeyFrame KeyTime="0:0:1.2"
+                                                          Value="1" />
+                                </DoubleAnimationUsingKeyFrames>
+                                <!--  Toggle the visible segment between fade out and fade in  -->
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Segment2"
+                                                               Storyboard.TargetProperty="(UIElement.Visibility)">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0"
+                                                            Value="Visible" />
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.6"
+                                                            Value="Collapsed" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Segment1"
+                                                               Storyboard.TargetProperty="(UIElement.Visibility)">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0"
+                                                            Value="Collapsed" />
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.6"
+                                                            Value="Visible" />
+                                </ObjectAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </Grid.Resources>
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="MarqueeStateGroup">
                                 <VisualState x:Name="MarqueeActive" />
@@ -89,39 +139,11 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-                        <Grid.Resources>
-                            <Storyboard x:Name="CyclingAnimation" Duration="0:0:1.2">
-                                <!--Animate the translation-->
-                                <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation" Duration="0:0:1.2" Storyboard.TargetProperty="(CompositeTransform.TranslateX)" Storyboard.TargetName="MarqueeTransform">
-                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
-                                    <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition" KeyTime="0:0:0.5" Value="20"/>
-                                    <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition" KeyTime="0:0:0.7" Value="-20"/>
-                                    <LinearDoubleKeyFrame KeyTime="0:0:1.2" Value="0"/>
-                                </DoubleAnimationUsingKeyFrames>
-                                <!--Animate the opacity-->
-                                <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="MarqueePanel">
-                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1"/>
-                                    <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="0"/>
-                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0.7" Value="0"/>
-                                    <LinearDoubleKeyFrame KeyTime="0:0:1.2" Value="1"/>
-                                </DoubleAnimationUsingKeyFrames>
-                                <!--Toggle the visible segment between fade out and fade in-->
-                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment2">
-                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible"/>
-                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="Collapsed"/>
-                                </ObjectAnimationUsingKeyFrames>
-                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment1">
-                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Collapsed"/>
-                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="Visible"/>
-                                </ObjectAnimationUsingKeyFrames>
-                            </Storyboard>
-                        </Grid.Resources>
-                        
                         <Grid x:Name="MarqueeContainer">
                             <StackPanel x:Name="MarqueePanel"
                                         Orientation="Horizontal">
                                 <StackPanel.RenderTransform>
-                                    <CompositeTransform x:Name="MarqueeTransform"/>
+                                    <CompositeTransform x:Name="MarqueeTransform" />
                                 </StackPanel.RenderTransform>
                                 <TextBlock x:Name="Segment1"
                                            win:FontStretch="{TemplateBinding FontStretch}"
@@ -132,7 +154,7 @@
                                            FontStyle="{TemplateBinding FontStyle}"
                                            FontWeight="{TemplateBinding FontWeight}"
                                            Foreground="{TemplateBinding Foreground}"
-                                           Text="{TemplateBinding Text}"/>
+                                           Text="{TemplateBinding Text}" />
                                 <TextBlock x:Name="Segment2"
                                            win:FontStretch="{TemplateBinding FontStretch}"
                                            win:TextDecorations="{TemplateBinding TextDecorations}"
@@ -143,7 +165,7 @@
                                            FontWeight="{TemplateBinding FontWeight}"
                                            Foreground="{TemplateBinding Foreground}"
                                            Text="{TemplateBinding SecondaryText}"
-                                           Visibility="Collapsed"/>
+                                           Visibility="Collapsed" />
                             </StackPanel>
                         </Grid>
                     </Grid>

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -73,6 +73,23 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
+                        <Grid.Resources>
+                            <Storyboard x:Name="CyclingAnimation" Duration="0:0:1.2">
+                                <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(TranslateTransform.X)" Storyboard.TargetName="MarqueeTransform">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
+                                    <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="20"/>
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0.7" Value="-20"/>
+                                    <LinearDoubleKeyFrame KeyTime="0:0:1.2" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="MarqueePanel">
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1"/>
+                                    <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="0"/>
+                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0.7" Value="0"/>
+                                    <LinearDoubleKeyFrame KeyTime="0:0:1.2" Value="1"/>
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </Grid.Resources>
+                        
                         <Grid x:Name="MarqueeContainer">
                             <StackPanel x:Name="MarqueePanel"
                                         Orientation="Horizontal">

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -65,21 +65,25 @@
                                 <VisualState x:Name="Ticker">
                                     <VisualState.Setters>
                                         <Setter Target="Segment1.Padding" Value="0" />
+                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Looping">
                                     <VisualState.Setters>
                                         <Setter Target="Segment1.Padding" Value="0,0,32,0" />
+                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Bouncing">
                                     <VisualState.Setters>
                                         <Setter Target="Segment1.Padding" Value="0" />
+                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Cycle">
                                     <VisualState.Setters>
                                         <Setter Target="Segment1.Padding" Value="0" />
+                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -87,18 +91,29 @@
 
                         <Grid.Resources>
                             <Storyboard x:Name="CyclingAnimation" Duration="0:0:1.2">
+                                <!--Animate the translation-->
                                 <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation" Duration="0:0:1.2" Storyboard.TargetProperty="(TranslateTransform.X)" Storyboard.TargetName="MarqueeTransform">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
                                     <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition" KeyTime="0:0:0.5" Value="20"/>
                                     <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition" KeyTime="0:0:0.7" Value="-20"/>
                                     <LinearDoubleKeyFrame KeyTime="0:0:1.2" Value="0"/>
                                 </DoubleAnimationUsingKeyFrames>
+                                <!--Animate the opacity-->
                                 <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="MarqueePanel">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="1"/>
                                     <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="0"/>
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0.7" Value="0"/>
                                     <LinearDoubleKeyFrame KeyTime="0:0:1.2" Value="1"/>
                                 </DoubleAnimationUsingKeyFrames>
+                                <!--Toggle the visible segment between fade out and fade in-->
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment2">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible"/>
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.5" Value="Collapsed"/>
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment1">
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Collapsed"/>
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.7" Value="Visible"/>
+                                </ObjectAnimationUsingKeyFrames>
                             </Storyboard>
                         </Grid.Resources>
                         
@@ -117,7 +132,7 @@
                                            FontStyle="{TemplateBinding FontStyle}"
                                            FontWeight="{TemplateBinding FontWeight}"
                                            Foreground="{TemplateBinding Foreground}"
-                                           Text="{TemplateBinding SecondaryText}" />
+                                           Text="{TemplateBinding Text}"/>
                                 <TextBlock x:Name="Segment2"
                                            win:FontStretch="{TemplateBinding FontStretch}"
                                            win:TextDecorations="{TemplateBinding TextDecorations}"
@@ -127,7 +142,8 @@
                                            FontStyle="{TemplateBinding FontStyle}"
                                            FontWeight="{TemplateBinding FontWeight}"
                                            Foreground="{TemplateBinding Foreground}"
-                                           Text="{TemplateBinding Text}" />
+                                           Text="{TemplateBinding SecondaryText}"
+                                           Visibility="Collapsed"/>
                             </StackPanel>
                         </Grid>
                     </Grid>

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -108,11 +108,11 @@
                                 <!--Toggle the visible segment between fade out and fade in-->
                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment2">
                                     <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible"/>
-                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.5" Value="Collapsed"/>
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="Collapsed"/>
                                 </ObjectAnimationUsingKeyFrames>
                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="Segment1">
                                     <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Collapsed"/>
-                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.7" Value="Visible"/>
+                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="Visible"/>
                                 </ObjectAnimationUsingKeyFrames>
                             </Storyboard>
                         </Grid.Resources>

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -3,8 +3,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarqueeTextRns"
                     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-    
-    <Style x:Key="MarqueeTextTickerStyle" TargetType="labs:MarqueeText">
+
+    <Style TargetType="labs:MarqueeText">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Template">
@@ -19,94 +19,7 @@
                           CornerRadius="{TemplateBinding CornerRadius}">
 
                         <Grid.Resources>
-                            <Storyboard x:Name="MarqueeAnimation"
-                                        Duration="Automatic">
-                                <!--  Animate the translation  -->
-                                <DoubleAnimation x:Name="TranslationAnimation"
-                                                 Storyboard.TargetName="MarqueeTransform"
-                                                 Storyboard.TargetProperty="(CompositeTransform.TranslateX)"
-                                                 Duration="0:0:20" From="{Binding ElementName=MarqueeContainer, Path=ActualWidth, Mode=OneWay}" To="0"/>
-                            </Storyboard>
-                        </Grid.Resources>
-
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="MarqueeStateGroup">
-                                <VisualState x:Name="MarqueeActive" />
-                                <VisualState x:Name="MarqueeStopped">
-                                    <VisualState.Setters>
-                                        <Setter Target="MarqueeTransform.TranslateX" Value="0.0" />
-                                        <Setter Target="MarqueeTransform.TranslateY" Value="0.0" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="DirectionStateGroup">
-                                <VisualState x:Name="Leftwards">
-                                    <VisualState.Setters>
-                                        <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
-                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Rightwards">
-                                    <VisualState.Setters>
-                                        <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
-                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Upwards">
-                                    <VisualState.Setters>
-                                        <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
-                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Downwards">
-                                    <VisualState.Setters>
-                                        <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
-                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-
-                        <Grid x:Name="MarqueeContainer">
-                            <StackPanel x:Name="MarqueePanel"
-                                        Orientation="Horizontal">
-                                <StackPanel.RenderTransform>
-                                    <CompositeTransform x:Name="MarqueeTransform" />
-                                </StackPanel.RenderTransform>
-                                <TextBlock x:Name="Segment1"
-                                           win:FontStretch="{TemplateBinding FontStretch}"
-                                           win:TextDecorations="{TemplateBinding TextDecorations}"
-                                           CharacterSpacing="{TemplateBinding CharacterSpacing}"
-                                           FontFamily="{TemplateBinding FontFamily}"
-                                           FontSize="{TemplateBinding FontSize}"
-                                           FontStyle="{TemplateBinding FontStyle}"
-                                           FontWeight="{TemplateBinding FontWeight}"
-                                           Foreground="{TemplateBinding Foreground}"
-                                           Text="{TemplateBinding Text}" />
-                            </StackPanel>
-                        </Grid>
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-    
-    <Style x:Key="MarqueeTextCycleStyle" TargetType="labs:MarqueeText">
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="VerticalAlignment" Value="Top" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="labs:MarqueeText">
-                    <Grid Padding="{TemplateBinding Padding}"
-                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                          VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                          Background="{TemplateBinding Background}"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="{TemplateBinding BorderThickness}"
-                          CornerRadius="{TemplateBinding CornerRadius}">
-
-                        <Grid.Resources>
-                            <Storyboard x:Name="MarqueeAnimation"
+                            <Storyboard x:Name="CyclingAnimation"
                                         Duration="0:0:1.2">
                                 <!--  Animate the translation  -->
                                 <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"
@@ -198,6 +111,32 @@
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
+                            <VisualStateGroup x:Name="BehaviorStateGroup">
+                                <VisualState x:Name="Ticker">
+                                    <VisualState.Setters>
+                                        <Setter Target="Segment1.Padding" Value="0" />
+                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Looping">
+                                    <VisualState.Setters>
+                                        <Setter Target="Segment1.Padding" Value="0,0,32,0" />
+                                        <Setter Target="Segment2.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Bouncing">
+                                    <VisualState.Setters>
+                                        <Setter Target="Segment1.Padding" Value="0" />
+                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Cycle">
+                                    <VisualState.Setters>
+                                        <Setter Target="Segment1.Padding" Value="0" />
+                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
                         <Grid x:Name="MarqueeContainer">
@@ -234,7 +173,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-
-    <!--  Make Ticker the default style  -->
-    <Style TargetType="labs:MarqueeText" BasedOn="{StaticResource MarqueeTextTickerStyle}"/>
 </ResourceDictionary>

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -22,8 +22,8 @@
                                 <VisualState x:Name="MarqueeActive" />
                                 <VisualState x:Name="MarqueeStopped">
                                     <VisualState.Setters>
-                                        <Setter Target="MarqueeTransform.X" Value="0.0" />
-                                        <Setter Target="MarqueeTransform.Y" Value="0.0" />
+                                        <Setter Target="MarqueeTransform.TranslateX" Value="0.0" />
+                                        <Setter Target="MarqueeTransform.TranslateY" Value="0.0" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -31,7 +31,7 @@
                                 <VisualState x:Name="Leftwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.X)" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
                                         <Setter Target="CycleAnimationFadeOutPosition.Value" Value="-20" />
                                         <Setter Target="CycleAnimationFadeInPosition.Value" Value="20" />
                                     </VisualState.Setters>
@@ -39,7 +39,7 @@
                                 <VisualState x:Name="Rightwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.X)" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
                                         <Setter Target="CycleAnimationFadeOutPosition.Value" Value="20" />
                                         <Setter Target="CycleAnimationFadeInPosition.Value" Value="-20" />
                                     </VisualState.Setters>
@@ -47,7 +47,7 @@
                                 <VisualState x:Name="Upwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.Y)" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
                                         <Setter Target="CycleAnimationFadeOutPosition.Value" Value="-20" />
                                         <Setter Target="CycleAnimationFadeInPosition.Value" Value="20" />
                                     </VisualState.Setters>
@@ -55,7 +55,7 @@
                                 <VisualState x:Name="Downwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
-                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.Y)" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
                                         <Setter Target="CycleAnimationFadeOutPosition.Value" Value="20" />
                                         <Setter Target="CycleAnimationFadeInPosition.Value" Value="-20" />
                                     </VisualState.Setters>
@@ -92,7 +92,7 @@
                         <Grid.Resources>
                             <Storyboard x:Name="CyclingAnimation" Duration="0:0:1.2">
                                 <!--Animate the translation-->
-                                <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation" Duration="0:0:1.2" Storyboard.TargetProperty="(TranslateTransform.X)" Storyboard.TargetName="MarqueeTransform">
+                                <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation" Duration="0:0:1.2" Storyboard.TargetProperty="(CompositeTransform.TranslateX)" Storyboard.TargetName="MarqueeTransform">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
                                     <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition" KeyTime="0:0:0.5" Value="20"/>
                                     <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition" KeyTime="0:0:0.7" Value="-20"/>
@@ -121,7 +121,7 @@
                             <StackPanel x:Name="MarqueePanel"
                                         Orientation="Horizontal">
                                 <StackPanel.RenderTransform>
-                                    <TranslateTransform x:Name="MarqueeTransform" />
+                                    <CompositeTransform x:Name="MarqueeTransform"/>
                                 </StackPanel.RenderTransform>
                                 <TextBlock x:Name="Segment1"
                                            win:FontStretch="{TemplateBinding FontStretch}"

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -31,21 +31,33 @@
                                 <VisualState x:Name="Leftwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.X)" />
+                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="-20" />
+                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="20" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Rightwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.X)" />
+                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="20" />
+                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="-20" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Upwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.Y)" />
+                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="-20" />
+                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="20" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Downwards">
                                     <VisualState.Setters>
                                         <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
+                                        <Setter Target="CycleAnimationTranslationAnimation.(Storyboard.TargetProperty)" Value="(TranslateTransform.Y)" />
+                                        <Setter Target="CycleAnimationFadeOutPosition.Value" Value="20" />
+                                        <Setter Target="CycleAnimationFadeInPosition.Value" Value="-20" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -75,10 +87,10 @@
 
                         <Grid.Resources>
                             <Storyboard x:Name="CyclingAnimation" Duration="0:0:1.2">
-                                <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(TranslateTransform.X)" Storyboard.TargetName="MarqueeTransform">
+                                <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation" Duration="0:0:1.2" Storyboard.TargetProperty="(TranslateTransform.X)" Storyboard.TargetName="MarqueeTransform">
                                     <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>
-                                    <LinearDoubleKeyFrame KeyTime="0:0:0.5" Value="20"/>
-                                    <DiscreteDoubleKeyFrame KeyTime="0:0:0.7" Value="-20"/>
+                                    <LinearDoubleKeyFrame x:Name="CycleAnimationFadeOutPosition" KeyTime="0:0:0.5" Value="20"/>
+                                    <DiscreteDoubleKeyFrame x:Name="CycleAnimationFadeInPosition" KeyTime="0:0:0.7" Value="-20"/>
                                     <LinearDoubleKeyFrame KeyTime="0:0:1.2" Value="0"/>
                                 </DoubleAnimationUsingKeyFrames>
                                 <DoubleAnimationUsingKeyFrames Duration="0:0:1.2" Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="MarqueePanel">
@@ -105,7 +117,7 @@
                                            FontStyle="{TemplateBinding FontStyle}"
                                            FontWeight="{TemplateBinding FontWeight}"
                                            Foreground="{TemplateBinding Foreground}"
-                                           Text="{TemplateBinding Text}" />
+                                           Text="{TemplateBinding SecondaryText}" />
                                 <TextBlock x:Name="Segment2"
                                            win:FontStretch="{TemplateBinding FontStretch}"
                                            win:TextDecorations="{TemplateBinding TextDecorations}"

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -3,8 +3,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarqueeTextRns"
                     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-
-    <Style TargetType="labs:MarqueeText">
+    
+    <Style x:Key="MarqueeTextTickerStyle" TargetType="labs:MarqueeText">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Template">
@@ -19,7 +19,94 @@
                           CornerRadius="{TemplateBinding CornerRadius}">
 
                         <Grid.Resources>
-                            <Storyboard x:Name="CyclingAnimation"
+                            <Storyboard x:Name="MarqueeAnimation"
+                                        Duration="Automatic">
+                                <!--  Animate the translation  -->
+                                <DoubleAnimation x:Name="TranslationAnimation"
+                                                 Storyboard.TargetName="MarqueeTransform"
+                                                 Storyboard.TargetProperty="(CompositeTransform.TranslateX)"
+                                                 Duration="0:0:20" From="{Binding ElementName=MarqueeContainer, Path=ActualWidth, Mode=OneWay}" To="0"/>
+                            </Storyboard>
+                        </Grid.Resources>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="MarqueeStateGroup">
+                                <VisualState x:Name="MarqueeActive" />
+                                <VisualState x:Name="MarqueeStopped">
+                                    <VisualState.Setters>
+                                        <Setter Target="MarqueeTransform.TranslateX" Value="0.0" />
+                                        <Setter Target="MarqueeTransform.TranslateY" Value="0.0" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="DirectionStateGroup">
+                                <VisualState x:Name="Leftwards">
+                                    <VisualState.Setters>
+                                        <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
+                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Rightwards">
+                                    <VisualState.Setters>
+                                        <Setter Target="MarqueePanel.Orientation" Value="Horizontal" />
+                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateX)" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Upwards">
+                                    <VisualState.Setters>
+                                        <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
+                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Downwards">
+                                    <VisualState.Setters>
+                                        <Setter Target="MarqueePanel.Orientation" Value="Vertical" />
+                                        <Setter Target="TranslationAnimation.(Storyboard.TargetProperty)" Value="(CompositeTransform.TranslateY)" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid x:Name="MarqueeContainer">
+                            <StackPanel x:Name="MarqueePanel"
+                                        Orientation="Horizontal">
+                                <StackPanel.RenderTransform>
+                                    <CompositeTransform x:Name="MarqueeTransform" />
+                                </StackPanel.RenderTransform>
+                                <TextBlock x:Name="Segment1"
+                                           win:FontStretch="{TemplateBinding FontStretch}"
+                                           win:TextDecorations="{TemplateBinding TextDecorations}"
+                                           CharacterSpacing="{TemplateBinding CharacterSpacing}"
+                                           FontFamily="{TemplateBinding FontFamily}"
+                                           FontSize="{TemplateBinding FontSize}"
+                                           FontStyle="{TemplateBinding FontStyle}"
+                                           FontWeight="{TemplateBinding FontWeight}"
+                                           Foreground="{TemplateBinding Foreground}"
+                                           Text="{TemplateBinding Text}" />
+                            </StackPanel>
+                        </Grid>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <Style x:Key="MarqueeTextCycleStyle" TargetType="labs:MarqueeText">
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="labs:MarqueeText">
+                    <Grid Padding="{TemplateBinding Padding}"
+                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                          VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                          Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          CornerRadius="{TemplateBinding CornerRadius}">
+
+                        <Grid.Resources>
+                            <Storyboard x:Name="MarqueeAnimation"
                                         Duration="0:0:1.2">
                                 <!--  Animate the translation  -->
                                 <DoubleAnimationUsingKeyFrames x:Name="CycleAnimationTranslationAnimation"
@@ -111,32 +198,6 @@
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
-                            <VisualStateGroup x:Name="BehaviorStateGroup">
-                                <VisualState x:Name="Ticker">
-                                    <VisualState.Setters>
-                                        <Setter Target="Segment1.Padding" Value="0" />
-                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Looping">
-                                    <VisualState.Setters>
-                                        <Setter Target="Segment1.Padding" Value="0,0,32,0" />
-                                        <Setter Target="Segment2.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Bouncing">
-                                    <VisualState.Setters>
-                                        <Setter Target="Segment1.Padding" Value="0" />
-                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="Cycle">
-                                    <VisualState.Setters>
-                                        <Setter Target="Segment1.Padding" Value="0" />
-                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
                         <Grid x:Name="MarqueeContainer">
@@ -173,4 +234,7 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!--  Make Ticker the default style  -->
+    <Style TargetType="labs:MarqueeText" BasedOn="{StaticResource MarqueeTextTickerStyle}"/>
 </ResourceDictionary>

--- a/components/MarqueeText/src/MarqueeText.xaml
+++ b/components/MarqueeText/src/MarqueeText.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarqueeTextRns"
@@ -121,7 +121,7 @@
                                 <VisualState x:Name="Looping">
                                     <VisualState.Setters>
                                         <Setter Target="Segment1.Padding" Value="0,0,32,0" />
-                                        <Setter Target="Segment2.Visibility" Value="Collapsed" />
+                                        <Setter Target="Segment2.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Bouncing">


### PR DESCRIPTION
## Changes:

### Added Cycle Marquee Behavior option

When in cycle mode, an animation is played to transition between values when the `Text` property is changed.

https://github.com/CommunityToolkit/Labs-Windows/assets/9384045/e4a3e26a-1932-48dd-890d-63a5b8f092b8

### More predictable behavior

- Marquee animation no longer plays by default.
- Marquee animation is no longer started when the control's size changes.