### PR TITLE
Fix TitleBar Sample mucking up App's TitleBar

### DIFF
--- a/components/TitleBar/src/TitleBar.UWP.cs
+++ b/components/TitleBar/src/TitleBar.UWP.cs
@@ -30,16 +30,22 @@ public partial class TitleBar : Control
 
             PART_DragRegion = GetTemplateChild(nameof(PART_DragRegion)) as Grid;
             Window.Current.SetTitleBar(PART_DragRegion);
+
+            _isAutoConfigCompleted = true;
         }
     }
 
     private void ResetUWPTitleBar()
     {
-        CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
-        Window.Current.Activated -= this.Current_Activated;
-        SizeChanged -= this.TitleBar_SizeChanged;
-        CoreApplication.GetCurrentView().TitleBar.LayoutMetricsChanged -= this.TitleBar_LayoutMetricsChanged;
-        Window.Current.SetTitleBar(null);
+        // Only reset if we were the ones who configured
+        if (_isAutoConfigCompleted)
+        {
+            CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
+            Window.Current.Activated -= this.Current_Activated;
+            SizeChanged -= this.TitleBar_SizeChanged;
+            CoreApplication.GetCurrentView().TitleBar.LayoutMetricsChanged -= this.TitleBar_LayoutMetricsChanged;
+            Window.Current.SetTitleBar(null);
+        }
     }
 
     private void Current_Activated(object sender, Windows.UI.Core.WindowActivatedEventArgs e)

--- a/components/TitleBar/src/TitleBar.WASDK.cs
+++ b/components/TitleBar/src/TitleBar.WASDK.cs
@@ -76,6 +76,8 @@ public partial class TitleBar : Control
             // Recalculate the drag region for the custom title bar 
             // if you explicitly defined new draggable areas.
             SetDragRegionForCustomTitleBar();
+
+            _isAutoConfigCompleted = true;
         }
     }
 
@@ -108,11 +110,15 @@ public partial class TitleBar : Control
             // TO DO: Throw exception that window has not been set? 
         }
 
-        Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
-        this.Window.SizeChanged -= Window_SizeChanged;
-        this.Window.Activated -= Window_Activated;
-        SizeChanged -= this.TitleBar_SizeChanged;
-        Window.AppWindow.TitleBar.ResetToDefault();
+        // Only reset if we were the ones who configured
+        if (_isAutoConfigCompleted)
+        {
+            Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
+            this.Window.SizeChanged -= Window_SizeChanged;
+            this.Window.Activated -= Window_Activated;
+            SizeChanged -= this.TitleBar_SizeChanged;
+            Window.AppWindow.TitleBar.ResetToDefault();
+        }
     }
 
     private void Window_Activated(object sender, WindowActivatedEventArgs args)

--- a/components/TitleBar/src/TitleBar.cs
+++ b/components/TitleBar/src/TitleBar.cs
@@ -67,6 +67,10 @@ public partial class TitleBar : Control
     ColumnDefinition? PART_RightPaddingColumn;
     StackPanel? PART_ButtonHolder;
 
+    // Internal tracking (if AutoConfigureCustomTitleBar is on) if we've actually setup the TitleBar yet or not
+    // We only want to reset TitleBar configuration in app, if we're the TitleBar instance that's managing that state.
+    private bool _isAutoConfigCompleted = false;
+
     public TitleBar()
     {
         this.DefaultStyleKey = typeof(TitleBar);


### PR DESCRIPTION
Add internal check for TitleBar code so that it only resets the App's TitleBar if it was the initializer of the setup originally

Before this change, if you opened the TitleBar sample the App's TitleBar customizations would be reset. After this change, that no longer occurs.