### PR TITLE
MultiTarget Matrix for CI, support for solution generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,19 +234,10 @@ jobs:
         with:
           submodules: recursive
           
-      # Semver regex: https://regex101.com/r/Ly7O1x/3/
-      - name: Format Date/Time of Release Package Version
-        if: ${{ env.IS_RELEASE == 'true' }}
-        run: |
-          $ref = "${{ github.ref }}"
-          $ref -match "^refs/heads/rel/(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-          echo "VERSION_DATE=$($matches['patch'])" >> $env:GITHUB_ENV
-          echo "VERSION_PROPERTY=$($matches['prerelease'])" >> $env:GITHUB_ENV
-
       - name: Format Date/Time of Commit for Package Version
-        if: ${{ env.IS_RELEASE == 'false' }}
         run: |
           echo "VERSION_DATE=$(git log -1 --format=%cd --date=format:%y%m%d)" >> $env:GITHUB_ENV
+
       - name: Restore dotnet tools
         run: dotnet tool restore
 
@@ -260,7 +251,7 @@ jobs:
           --skip androidemulator
           --skip vswinworkloads
           --verbose
-          
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,17 @@ jobs:
 
     # See https://docs.github.com/actions/using-jobs/using-a-matrix-for-your-jobs
     strategy:
-      fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them both to run to completion.
+      fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
       matrix:
-        platform: [WinUI2, WinUI3]
+        winui: [2, 3]
+        multitarget: ['uwp', 'wasdk', 'wasm', 'wpf', 'linuxgtk', 'macos', 'ios', 'android']
+        exclude:
+          # WinUI 2 not supported on wasdk
+          - winui: 2
+            multitarget: wasdk
+          # WinUI 3 not supported on uwp
+          - winui: 3
+            multitarget: uwp
 
     env:
       MULTI_TARGET_DIRECTORY: tooling/MultiTarget
@@ -107,10 +115,12 @@ jobs:
         run: dotnet tool restore
 
       - name: Run Uno Check to Install Dependencies
+        if: ${{ matrix.multitarget != 'wasdk' && matrix.multitarget != 'linuxgtk' && matrix.multitarget != 'wpf' }}
         run: >
           dotnet tool run uno-check 
           --ci
           --fix
+          --target ${{ matrix.multitarget }}
           --non-interactive
           --skip wsl
           --skip androidemulator
@@ -122,23 +132,12 @@ jobs:
         with:
           vs-version: '[17.9,)'
 
-      - name: Enable ${{ env.TARGET_PLATFORMS }} TargetFrameworks
-        working-directory: ./${{ env.MULTI_TARGET_DIRECTORY }} 
-        run: powershell -version 5.1 -command "./UseTargetFrameworks.ps1 ${{ env.TARGET_PLATFORMS }}" -ErrorAction Stop
-
-      - name: Generate solution w/ ${{ env.TEST_PLATFORM }} Tests
+      # Generate full solution with all projects (sample gallery heads, components, tests)
+      - name: Generate solution with ${{ matrix.multitarget }} gallery, components and tests
         working-directory: ./
-        run: powershell -version 5.1 -command "./tooling/GenerateAllSolution.ps1 -IncludeHeads ${{ env.TEST_PLATFORM }}${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}" -ErrorAction Stop
+        run: powershell -version 5.1 -command "./tooling/GenerateAllSolution.ps1 -MultiTargets ${{ matrix.multitarget }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }} -WinUIMajorVersion ${{ matrix.winui }}" -ErrorAction Stop
 
-      - name: Enable Uno.WinUI (in WinUI3 matrix only)
-        if: ${{ matrix.platform == 'WinUI3' }}
-        working-directory: ./${{ env.MULTI_TARGET_DIRECTORY }}
-        run: powershell -version 5.1 -command "./UseUnoWinUI.ps1 3" -ErrorAction Stop
-
-      - name: Format Date/Time of Commit for Package Version
-        run: |
-          echo "VERSION_DATE=$(git log -1 --format=%cd --date=format:%y%m%d)" >> $env:GITHUB_ENV
-
+      # Build solution
       - name: MSBuild (With diagnostics)
         if: ${{ env.ENABLE_DIAGNOSTICS == 'true' }}
         run: >
@@ -151,32 +150,7 @@ jobs:
 
       - name: MSBuild
         if: ${{ env.ENABLE_DIAGNOSTICS == 'false' }}
-        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release 
-
-      # Build All Packages
-      - name: Pack experiments
-        working-directory: ./tooling/Scripts/
-        run: ./PackEachExperiment.ps1 -date ${{ env.VERSION_DATE }}${{ env.VERSION_PROPERTY != '' && format(' -postfix {0}', env.VERSION_PROPERTY) || '' }}
-
-      - name: Validate package names
-        if: ${{ env.VERSION_PROPERTY != '' }}
-        run: powershell -version 5.1 -command "Get-ChildItem -Path '**/*.nupkg' | ForEach-Object { if (`$_.Name -notmatch '${{ env.VERSION_PROPERTY }}') { throw 'Nupkg name is missing trailing VERSION_PROPERTY' + `$_.Name } }" -ErrorAction Stop
-
-      # Push Pull Request Packages to our DevOps Artifacts Feed (see nuget.config)
-      - name: Push PR packages (if not fork)
-        if: ${{ env.IS_PR == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
-        run: |
-          dotnet nuget add source https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-PullRequests/nuget/v3/index.json `
-            --name PullRequests `
-            --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
-          dotnet nuget push "**/*.nupkg" --api-key dummy --source PullRequests --skip-duplicate
-
-      - name: Push packages (main)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          dotnet nuget update source LabsFeed `
-            --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
-          dotnet nuget push "**/*.nupkg" --api-key dummy --source LabsFeed --skip-duplicate
+        run: msbuild.exe CommunityToolkit.AllComponents.sln /restore /nowarn:MSB4011 -p:Configuration=Release
 
       # Run tests
       - name: Setup VSTest Path
@@ -187,20 +161,21 @@ jobs:
         with:
           domain: ${{ github.repository_owner }}
 
-      - name: Run experiment tests against ${{ env.TEST_PLATFORM }}
+      - name: Run component tests against ${{ matrix.multitarget }}
+        if: ${{ matrix.multitarget == 'uwp' || matrix.multitarget == 'wasdk' }}
         id: test-platform
-        run:  vstest.console.exe ./tooling/**/CommunityToolkit.Tests.${{ env.TEST_PLATFORM }}.build.appxrecipe /Framework:FrameworkUap10 /logger:"trx;LogFileName=${{ env.TEST_PLATFORM }}.trx" /Blame
+        run:  vstest.console.exe ./tooling/**/CommunityToolkit.Tests.${{ matrix.multitarget }}.build.appxrecipe /Framework:FrameworkUap10 /logger:"trx;LogFileName=${{ matrix.multitarget }}.trx" /Blame
 
       - name: Create test reports
         run: |
-          testspace '[${{ matrix.platform }}]./TestResults/*.trx'
-        if: ${{ always() && (steps.test-generator.conclusion == 'success' || steps.test-platform.conclusion == 'success') }}
+          testspace '[${{ matrix.multitarget }}]./TestResults/*.trx'
+        if: ${{ (matrix.multitarget == 'uwp' || matrix.multitarget == 'wasdk') && (steps.test-generator.conclusion == 'success' || steps.test-platform.conclusion == 'success') }}
 
       - name: Artifact - Diagnostic Logs
         uses: actions/upload-artifact@v4
         if: ${{ (env.ENABLE_DIAGNOSTICS == 'true' || env.COREHOST_TRACE != '') && always() }}
         with:
-          name: build-logs-${{ matrix.platform }} 
+          name: build-logs-${{ matrix.multitarget }}-winui${{ matrix.winui }}
           path: ./**/*.*log
 
       - name: Artifact - ILC Repro
@@ -231,6 +206,106 @@ jobs:
         run: |
           dotnet tool install --global dotnet-dump
           dotnet-dump analyze ${{ steps.filter.outputs.dump_files }} -c "clrstack" -c "pe -lines" -c "exit"
+
+  package:
+    runs-on: windows-latest
+    needs: [build]
+    strategy:
+      fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
+      matrix:
+        winui: [2, 3]
+
+    env:
+      VERSION_PROPERTY: ${{ github.ref == 'refs/heads/main' && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
+
+    steps:
+      - name: Install .NET SDK v${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: .NET Info (if diagnostics)
+        if: ${{ env.ENABLE_DIAGNOSTICS == 'true' }}
+        run: dotnet --info
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          
+      # Semver regex: https://regex101.com/r/Ly7O1x/3/
+      - name: Format Date/Time of Release Package Version
+        if: ${{ env.IS_RELEASE == 'true' }}
+        run: |
+          $ref = "${{ github.ref }}"
+          $ref -match "^refs/heads/rel/(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+          echo "VERSION_DATE=$($matches['patch'])" >> $env:GITHUB_ENV
+          echo "VERSION_PROPERTY=$($matches['prerelease'])" >> $env:GITHUB_ENV
+
+      - name: Format Date/Time of Commit for Package Version
+        if: ${{ env.IS_RELEASE == 'false' }}
+        run: |
+          echo "VERSION_DATE=$(git log -1 --format=%cd --date=format:%y%m%d)" >> $env:GITHUB_ENV
+      - name: Restore dotnet tools
+        run: dotnet tool restore
+
+      - name: Run Uno Check to Install Dependencies
+        run: >
+          dotnet tool run uno-check
+          --ci
+          --fix
+          --non-interactive
+          --skip wsl
+          --skip androidemulator
+          --skip vswinworkloads
+          --verbose
+          
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: '[17.9,)'
+
+      # Build and pack component nupkg
+      - name: Build and pack component packages
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
+
+      - name: Validate package names
+        if: ${{ env.VERSION_PROPERTY != '' }}
+        run: powershell -version 5.1 -command "Get-ChildItem -Path '*.nupkg' | ForEach-Object { if (`$_.Name -notmatch '${{ env.VERSION_PROPERTY }}') { throw 'Nupkg name is missing trailing VERSION_PROPERTY' + `$_.Name } }" -ErrorAction Stop
+
+      # Push Pull Request Packages to our DevOps Artifacts Feed (see nuget.config)
+      - name: Push Pull Request Packages (if not fork)
+        if: ${{ env.IS_PR == 'true' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+        run: |
+          dotnet nuget add source https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-PullRequests/nuget/v3/index.json `
+            --name PullRequests `
+            --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
+          dotnet nuget push "*.nupkg" --api-key dummy --source PullRequests --skip-duplicate
+          
+      - name: Push packages (main)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          dotnet nuget update source LabsFeed `
+            --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
+          dotnet nuget push "**/*.nupkg" --api-key dummy --source LabsFeed --skip-duplicate
+
+      # if we're not doing a PR build (or it's a PR from a fork) then we upload our packages so we can sign as a separate job or have available to test.
+      - name: Upload Packages as Artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ env.IS_PR == 'false' || github.event.pull_request.head.repo.full_name != github.repository }}
+        with:
+          name: nuget-packages-winui${{ matrix.winui }}
+          if-no-files-found: error
+          path: |
+            ./*.nupkg
+          
+      - name: Artifact - Diagnostic Logs
+        uses: actions/upload-artifact@v4
+        if: ${{ (env.ENABLE_DIAGNOSTICS == 'true' || env.COREHOST_TRACE != '') && always() }}
+        with:
+          name: build-logs-winui${{ matrix.winui }}
+          path: ./*.*log
 
   wasm-linux:
     runs-on: ubuntu-latest

--- a/GenerateAllSolution.bat
+++ b/GenerateAllSolution.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-SET "IncludeHeads=%1"
-IF "%IncludeHeads%"=="" SET "IncludeHeads=all"
+SET "MultiTargets=%1"
+IF "%MultiTargets%"=="" SET "MultiTargets=all"
 
-powershell .\tooling\GenerateAllSolution.ps1 -IncludeHeads %IncludeHeads%
+powershell .\tooling\GenerateAllSolution.ps1 -MultiTargets %MultiTargets%


### PR DESCRIPTION
This PR
- Updates tooling with the latest fixes and improvements to multitarget support for solution generation
- Refactors the `build` job, splitting into `build` and `package`.
  - The `build` job is matrixed in line with the multitarget system
  - The `package` job is not matrixed and has been refactored to use our `./tooling/Build-Toolkit-Components.ps1` script.

Prerequisite PR: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/200