### PR TITLE
Update build requirements in readme

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,9 +32,9 @@ git clone --recurse-submodules https://github.com/CommunityToolkit/Labs-Windows.
 ## Build Requirements
 
 - Visual Studio 2022 (UWP & Desktop Workloads for .NET)
-- .NET 6 SDK
-- Windows App SDK
-- Windows SDK 19041
+- .NET 8 SDK
+- Windows 10 SDK, version 2004 (10.0.19041.0)
+- Windows 10 21H1 (Build 19043) or greater
 - Run `dotnet tool restore` from the project root to install SlnGen
 - Run build scripts from the [Developer Command Prompt for Visual Studio](https://learn.microsoft.com/visualstudio/ide/reference/command-prompt-powershell) or from elsewhere after adding `MSBuild.exe` to your PATH
 


### PR DESCRIPTION
Updates the build requirements section of the repo README, bumping .NET 6 to 8 and adding the minimum Windows 10 Version the toolkit can be built on.

Tested against:
- Windows 10 Version 1809 Build 17763
  - With net8, no Windows SDK (doesn't build)
  - With net8, Windows SDK 17763 (doesn't build uwp)
  - With net8, Windows SDK 17763 and 19041 (doesn't build uwp)
- Windows 10 Version 21H1 Build 19043
  - With net8, no Windows SDK (doesn't build)
  - With net8, Windows SDK 17763 (doesn't build uwp)
  - With net8, Windows SDK 17763 and 19041 (**builds uwp and wasdk**)