### PR TITLE
Update Microsoft.WindowsAppSDK to 1.6-preview2

### DIFF
--- a/components/TitleBar/src/InfoHelper.cs
+++ b/components/TitleBar/src/InfoHelper.cs
@@ -1,4 +1,8 @@
-﻿#if WINAPPSDK
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if WINAPPSDK
 using Windows.ApplicationModel;
 using Windows.Storage;
 using Windows.System.Profile;

--- a/components/TitleBar/src/NativeMethods.cs
+++ b/components/TitleBar/src/NativeMethods.cs
@@ -1,4 +1,8 @@
-﻿#if WINAPPSDK
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if WINAPPSDK
 using System.Runtime.InteropServices;
 
 namespace CommunityToolkit.WinUI.Controls;

--- a/components/TitleBar/src/WndProcHelper.cs
+++ b/components/TitleBar/src/WndProcHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 #if WINAPPSDK
 using System.Runtime.InteropServices;
 using WinRT.Interop;


### PR DESCRIPTION
This PR updates our tooling to use Microsoft.WindowsAppSDK 1.6-preview2 and removes prior workarounds only needed for preview1.

Prerequisite PR: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/208