### PR TITLE
Dep bump, fixed net80-windows10.0.22621.0 appearing in nupkg

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,8 @@
 <Project>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="5.2.0" PrivateAssets="all" Pack="false" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.7.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Align NuGet.Build.Tasks.Pack and Microsoft.SourceLink.GitHub with main toolkit repo.

Fixes an issue where `net80-windows10.0.22621.0` would appear in the nuget package.