### PR TITLE
Fix analyzer warnings for CsWinRTAotWarningLevel 2

### DIFF
--- a/components/Ribbon/src/DoubleList.cs
+++ b/components/Ribbon/src/DoubleList.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.WinUI.Controls;
 /// A list of <see cref="double"/> values.
 /// </summary>
 [CreateFromString(MethodName = "CommunityToolkit.WinUI.Controls.DoubleList.CreateFromString")]
-public class DoubleList : List<double>
+public partial class DoubleList : List<double>
 {
     /// <summary>
     /// Initializes a new instance of <see cref="DoubleList"/> that is empty and has the default


### PR DESCRIPTION
- Enables additional AoT analyzers by setting `CsWinRTAotWarningLevel` to 2, as suggested in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/195#discussion_r1722185832.
- Resolves and fixes new analyzer warnings/errors in code

Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/212