### PR TITLE
Add an extension method for getting string attribute value from HtmlN…

### DIFF
--- a/components/MarkdownTextBlock/src/Extensions.cs
+++ b/components/MarkdownTextBlock/src/Extensions.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Labs.WinUI.MarkdownTextBlock.TextElements;
 using System.Xml.Linq;
 using System.Globalization;
 using Windows.UI.ViewManagement;
+using HtmlAgilityPack;
 
 namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
 
@@ -721,5 +722,15 @@ public static class Extensions
         var accentBrush = new SolidColorBrush(accentColor);
 
         return accentBrush;
+    }
+
+    public static string GetAttribute(this HtmlNode node, string attributeName, string defaultValue)
+    {
+        if (attributeName == null)
+        {
+            throw new ArgumentNullException(nameof(attributeName));
+        }
+
+        return node.Attributes?[attributeName]?.Value ?? defaultValue;
     }
 }

--- a/components/MarkdownTextBlock/src/TextElements/Html/MyBlock.cs
+++ b/components/MarkdownTextBlock/src/TextElements/Html/MyBlock.cs
@@ -21,7 +21,7 @@ internal class MyBlock : IAddChild
     public MyBlock(HtmlNode block)
     {
         _htmlNode = block;
-        var align = _htmlNode.GetAttributeValue("align", "left");
+        var align = _htmlNode.GetAttribute("align", "left");
         _richTextBlocks = new List<RichTextBlock>();
         _paragraph = new Paragraph();
         _paragraph.TextAlignment = align switch

--- a/components/MarkdownTextBlock/src/TextElements/MyHeading.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyHeading.cs
@@ -55,7 +55,7 @@ internal class MyHeading : IAddChild
         _paragraph = new Paragraph();
         _config = config;
 
-        var align = _htmlNode.GetAttributeValue("align", "left");
+        var align = _htmlNode.GetAttribute("align", "left");
         _paragraph.TextAlignment = align switch
         {
             "left" => TextAlignment.Left,

--- a/components/MarkdownTextBlock/src/TextElements/MyHyperlink.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyHyperlink.cs
@@ -35,7 +35,7 @@ internal class MyHyperlink : IAddChild
     public MyHyperlink(HtmlNode htmlNode, string? baseUrl)
     {
         _baseUrl = baseUrl;
-        var url = htmlNode.GetAttributeValue("href", "#");
+        var url = htmlNode.GetAttribute("href", "#");
         _htmlNode = htmlNode;
         _hyperlink = new Hyperlink()
         {

--- a/components/MarkdownTextBlock/src/TextElements/MyHyperlinkButton.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyHyperlinkButton.cs
@@ -35,7 +35,7 @@ internal class MyHyperlinkButton : IAddChild
     {
         _baseUrl = baseUrl;
         _htmlNode = htmlNode;
-        var url = htmlNode.GetAttributeValue("href", "#");
+        var url = htmlNode.GetAttribute("href", "#");
         Init(url, baseUrl);
     }
 

--- a/components/MarkdownTextBlock/src/TextElements/MyImage.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyImage.cs
@@ -50,20 +50,20 @@ internal class MyImage : IAddChild
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
 #pragma warning disable CS8601 // Possible null reference assignment.
-        Uri.TryCreate(htmlNode.GetAttributeValue("src", "#"), UriKind.RelativeOrAbsolute, out _uri);
+        Uri.TryCreate(htmlNode.GetAttribute("src", "#"), UriKind.RelativeOrAbsolute, out _uri);
 #pragma warning restore CS8601 // Possible null reference assignment.
         _htmlNode = htmlNode;
         _imageProvider = config?.ImageProvider;
         _svgRenderer = config?.SVGRenderer == null ? new DefaultSVGRenderer() : config.SVGRenderer;
         Init();
         int.TryParse(
-            htmlNode.GetAttributeValue("width", "0"),
+            htmlNode.GetAttribute("width", "0"),
             NumberStyles.Integer,
             CultureInfo.InvariantCulture,
             out var width
         );
         int.TryParse(
-            htmlNode.GetAttributeValue("height", "0"),
+            htmlNode.GetAttribute("height", "0"),
             NumberStyles.Integer,
             CultureInfo.InvariantCulture,
             out var height


### PR DESCRIPTION
Adds an extension method for HtmlNode that gets the string attribute value and use it everywhere instead of using the underlying `HtmlNode.GetAttributeValue` method that's not AOT compatible.