### PR TITLE
Fix DataTable crash on resize when columns don't fit

### DIFF
--- a/components/DataTable/src/DataTable/DataTable.cs
+++ b/components/DataTable/src/DataTable/DataTable.cs
@@ -93,7 +93,12 @@ public partial class DataTable : Panel
                 // then invalidate the child arranges [don't re-measure and cause loop]...)
 
                 // For now, we'll just use the header content as a guideline to see if things work.
-                column.Measure(new Size(availableSize.Width - fixedWidth - autoSized, availableSize.Height));
+
+                // Avoid negative values when columns don't fit `availableSize`. Otherwise the `Size` constructor will throw.
+                double width = availableSize.Width - fixedWidth - autoSized;
+                if (width < 0)
+                    width = 0;
+                column.Measure(new Size(width, availableSize.Height));
 
                 // Keep track of already 'allotted' space, use either the maximum child size (if we know it) or the header content
                 autoSized += Math.Max(column.DesiredSize.Width, column.MaxChildDesiredWidth);

--- a/components/DataTable/src/DataTable/DataTable.cs
+++ b/components/DataTable/src/DataTable/DataTable.cs
@@ -96,8 +96,7 @@ public partial class DataTable : Panel
 
                 // Avoid negative values when columns don't fit `availableSize`. Otherwise the `Size` constructor will throw.
                 double width = availableSize.Width - fixedWidth - autoSized;
-                if (width < 0)
-                    width = 0;
+                width = Math.Max(width, 0);
                 column.Measure(new Size(width, availableSize.Height));
 
                 // Keep track of already 'allotted' space, use either the maximum child size (if we know it) or the header content

--- a/components/DataTable/src/DataTable/DataTable.cs
+++ b/components/DataTable/src/DataTable/DataTable.cs
@@ -95,9 +95,7 @@ public partial class DataTable : Panel
                 // For now, we'll just use the header content as a guideline to see if things work.
 
                 // Avoid negative values when columns don't fit `availableSize`. Otherwise the `Size` constructor will throw.
-                double width = availableSize.Width - fixedWidth - autoSized;
-                width = Math.Max(width, 0);
-                column.Measure(new Size(width, availableSize.Height));
+                column.Measure(new Size(Math.Max(availableSize.Width - fixedWidth - autoSized, 0), availableSize.Height));
 
                 // Keep track of already 'allotted' space, use either the maximum child size (if we know it) or the header content
                 autoSized += Math.Max(column.DesiredSize.Width, column.MaxChildDesiredWidth);


### PR DESCRIPTION
`DataTable` sometimes crashes on resize, typically when it gets narrow enough for its columns not to fit. Crash happens in `MeasureOverride` because of negative value passed to `Size` ctor.

The easiest way to reproduce is to set `DataTable`'s `HorizontalAlignment` to `Left` to disable "stretching" behavior. The following code snippet may be used (slightly modified version of `DataTableSample.xaml`):

```xaml
<ListView ItemsSource="{x:Bind InventoryItems}" HorizontalAlignment="Left">
    <ListView.Header>
        <controls:DataTable Margin="12,0,0,0" HorizontalAlignment="Left">
            <controls:DataColumn Content="Id" />
            <controls:DataColumn CanResize="True" Content="Name" />
            <!--  Each column can be text or quickly customized by containing any content or restyled of course  -->
            <controls:DataColumn>
                <TextBlock FontWeight="SemiBold" Text="Description" />
            </controls:DataColumn>
            <controls:DataColumn Content="Quantity"/>
        </controls:DataTable>
    </ListView.Header>
    <ListView.ItemTemplate>
        <DataTemplate x:DataType="local:InventoryItem">
            <controls:DataRow HorizontalAlignment="Left">
                <TextBlock VerticalAlignment="Center" Text="{x:Bind Id}" />
                <TextBlock VerticalAlignment="Center" Text="{x:Bind Name}" />
                <TextBlock VerticalAlignment="Center" Text="{x:Bind Description}" />
                <TextBlock VerticalAlignment="Center" Text="{x:Bind Quantity}" />
            </controls:DataRow>
        </DataTemplate>
    </ListView.ItemTemplate>
    <ListView.ItemContainerStyle>
        <Style BasedOn="{StaticResource DefaultListViewItemStyle}"
                TargetType="ListViewItem">
            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
        </Style>
    </ListView.ItemContainerStyle>
</ListView>
```

This PR adds a check to make sure width value used in `MeasureOverride()` are non-negative.