### PR TITLE
Exclude uwp/wasdk MultiTarget in WinUI 2/3 packages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,9 +257,19 @@ jobs:
         with:
           vs-version: '[17.9,)'
 
+      - name: Define excluded MultiTargets (WinUI 2)
+        if: ${{ matrix.winui == '2' }}
+        run: |
+          echo "EXCLUDED_MULTITARGETS=wasdk" >> $env:GITHUB_ENV
+
+      - name: Define excluded MultiTargets (WinUI 3)
+        if: ${{ matrix.winui == '3' }}
+        run: |
+          echo "EXCLUDED_MULTITARGETS=uwp" >> $env:GITHUB_ENV
+          
       # Build and pack component nupkg
       - name: Build and pack component packages
-        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
 
       - name: Validate package names
         if: ${{ env.VERSION_PROPERTY != '' }}


### PR DESCRIPTION
This PR fixes an issue where the packaging step in our CI wasn't properly excluding wasdk when building WinUI 2 and uwp when building WinUI 3. 

Originally intended to be deployed alongside https://github.com/CommunityToolkit/Windows/pull/500.