### PR TITLE
MarkdownTextBlock: Enable/Disable built in extensions

### DIFF
--- a/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
+++ b/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
@@ -1,13 +1,12 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page
-    x:Class="MarkdownTextBlockExperiment.Samples.MarkdownTextBlockCustomSample"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:MarkdownTextBlockExperiment.Samples"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+<Page x:Class="MarkdownTextBlockExperiment.Samples.MarkdownTextBlockCustomSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:MarkdownTextBlockExperiment.Samples"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -16,40 +15,35 @@
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        <TextBlock
-            Grid.Row="0"
-            Margin="0,0,0,12"
-            FontSize="16"
-            FontWeight="Bold"
-            Text="Try it live!" />
+        <TextBlock Grid.Row="0"
+                   Margin="0,0,0,12"
+                   FontSize="16"
+                   FontWeight="Bold"
+                   Text="Try it live!" />
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <controls:MarkdownTextBlock
-                Grid.Column="0"
-                Config="{x:Bind LiveMarkdownConfig, Mode=OneTime}"
-                Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}" />
-            <TextBox
-                x:Name="MarkdownTextBox"
-                Grid.Column="1"
-                AcceptsReturn="True" />
+            <controls:MarkdownTextBlock Grid.Column="0"
+                                        Config="{x:Bind LiveMarkdownConfig, Mode=OneTime}"
+                                        Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}" />
+            <TextBox x:Name="MarkdownTextBox"
+                     Grid.Column="1"
+                     AcceptsReturn="True" />
         </Grid>
-        <TextBlock
-            Grid.Row="2"
-            Margin="0,0,0,12"
-            FontSize="16"
-            FontWeight="Bold"
-            Text="Built-in Sample" />
-        <controls:MarkdownTextBlock
-            Grid.Row="3"
-            Config="{x:Bind MarkdownConfig, Mode=OneTime}"
-            Text="{x:Bind Text, Mode=OneTime}"
-            UseAutoLinks="True"
-            UseEmphasisExtras="True"
-            UseListExtras="True"
-            UsePipeTables="True"
-            UseTaskLists="True" />
+        <TextBlock Grid.Row="2"
+                   Margin="0,0,0,12"
+                   FontSize="16"
+                   FontWeight="Bold"
+                   Text="Built-in Sample" />
+        <controls:MarkdownTextBlock Grid.Row="3"
+                                    Config="{x:Bind MarkdownConfig, Mode=OneTime}"
+                                    Text="{x:Bind Text, Mode=OneTime}"
+                                    UseAutoLinks="True"
+                                    UseEmphasisExtras="True"
+                                    UseListExtras="True"
+                                    UsePipeTables="True"
+                                    UseTaskLists="True" />
     </Grid>
 </Page>

--- a/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
+++ b/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
@@ -1,12 +1,13 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="MarkdownTextBlockExperiment.Samples.MarkdownTextBlockCustomSample"
-      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:controls="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:local="using:MarkdownTextBlockExperiment.Samples"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      mc:Ignorable="d">
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page
+    x:Class="MarkdownTextBlockExperiment.Samples.MarkdownTextBlockCustomSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:MarkdownTextBlockExperiment.Samples"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -15,30 +16,40 @@
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0"
-                   Margin="0,0,0,12"
-                   FontSize="16"
-                   FontWeight="Bold"
-                   Text="Try it live!" />
+        <TextBlock
+            Grid.Row="0"
+            Margin="0,0,0,12"
+            FontSize="16"
+            FontWeight="Bold"
+            Text="Try it live!" />
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <controls:MarkdownTextBlock Grid.Column="0"
-                                        Config="{x:Bind LiveMarkdownConfig, Mode=OneTime}"
-                                        Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}" />
-            <TextBox x:Name="MarkdownTextBox"
-                     Grid.Column="1"
-                     AcceptsReturn="True" />
+            <controls:MarkdownTextBlock
+                Grid.Column="0"
+                Config="{x:Bind LiveMarkdownConfig, Mode=OneTime}"
+                Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}" />
+            <TextBox
+                x:Name="MarkdownTextBox"
+                Grid.Column="1"
+                AcceptsReturn="True" />
         </Grid>
-        <TextBlock Grid.Row="2"
-                   Margin="0,0,0,12"
-                   FontSize="16"
-                   FontWeight="Bold"
-                   Text="Built-in Sample" />
-        <controls:MarkdownTextBlock Grid.Row="3"
-                                    Config="{x:Bind MarkdownConfig, Mode=OneTime}"
-                                    Text="{x:Bind Text, Mode=OneTime}" />
+        <TextBlock
+            Grid.Row="2"
+            Margin="0,0,0,12"
+            FontSize="16"
+            FontWeight="Bold"
+            Text="Built-in Sample" />
+        <controls:MarkdownTextBlock
+            Grid.Row="3"
+            Config="{x:Bind MarkdownConfig, Mode=OneTime}"
+            Text="{x:Bind Text, Mode=OneTime}"
+            UseAutoLinks="True"
+            UseEmphasisExtras="True"
+            UseListExtras="True"
+            UsePipeTables="True"
+            UseTaskLists="True" />
     </Grid>
 </Page>

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+
+public partial class MarkdownTextBlock
+{
+    /// <summary>
+    /// Identifies the <see cref="Config"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty ConfigProperty = DependencyProperty.Register(
+        nameof(Config),
+        typeof(MarkdownConfig),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(null, OnConfigChanged)
+    );
+
+    /// <summary>
+    /// Identifies the <see cref="Text"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+        nameof(Text),
+        typeof(string),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(null, OnTextChanged));
+
+    /// <summary>
+    /// Identifies the <see cref="UseEmphasisExtras"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty UseEmphasisExtrasProperty = DependencyProperty.Register(
+        nameof(UseEmphasisExtras),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    /// <summary>
+    /// Identifies the <see cref="UsePipeTables"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty UsePipeTablesProperty = DependencyProperty.Register(
+        nameof(UsePipeTables),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    /// <summary>
+    /// Identifies the <see cref="UseListExtras"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty UseListExtrasProperty = DependencyProperty.Register(
+        nameof(UseListExtras),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    /// <summary>
+    /// Identifies the <see cref="UseTaskLists"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty UseTaskListsProperty = DependencyProperty.Register(
+        nameof(UseTaskLists),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    /// <summary>
+    /// Identifies the <see cref="UseAutoLinks"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty UseAutoLinksProperty = DependencyProperty.Register(
+        nameof(UseAutoLinks),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    /// <summary>
+    /// Identifies the <see cref="UseSoftlineBreakAsHardlineBreak"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty UseSoftlineBreakAsHardlineBreakProperty = DependencyProperty.Register(
+        nameof(UseSoftlineBreakAsHardlineBreak),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    public MarkdownConfig Config
+    {
+        get => (MarkdownConfig)GetValue(ConfigProperty);
+        set => SetValue(ConfigProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the markdown text to display.
+    /// </summary>
+    public string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    /// <summary>
+    /// If true, adds support for strikethroughs, superscript, subscript, inserted, and marked text.
+    /// </summary>
+    public bool UseEmphasisExtras
+    {
+        get => (bool)GetValue(UseEmphasisExtrasProperty);
+        set => SetValue(UseEmphasisExtrasProperty, value);
+    }
+
+    /// <summary>
+    /// If true, adds support for GitHub-style pipe tables.
+    /// </summary>
+    public bool UsePipeTables
+    {
+        get => (bool)GetValue(UsePipeTablesProperty);
+        set => SetValue(UsePipeTablesProperty, value);
+    }
+
+    /// <summary>
+    /// If true, adds support for alphabetic and roman numbering in lists.
+    /// </summary>
+    public bool UseListExtras
+    {
+        get => (bool)GetValue(UseListExtrasProperty);
+        set => SetValue(UseListExtrasProperty, value);
+    }
+
+    /// <summary>
+    /// If true, adds support for GitHub-style task lists using the [ ] and [x] syntax.
+    /// </summary>
+    public bool UseTaskLists
+    {
+        get => (bool)GetValue(UseTaskListsProperty);
+        set => SetValue(UseTaskListsProperty, value);
+    }
+
+    /// <summary>
+    /// If true, parses text that looks like URIs into hyperlinks (e.g. https://...).
+    /// </summary>
+    public bool UseAutoLinks
+    {
+        get => (bool)GetValue(UseAutoLinksProperty);
+        set => SetValue(UseAutoLinksProperty, value);
+    }
+
+    /// <summary>
+    /// If true, considers single newlines as hardline breaks.
+    /// </summary>
+    public bool UseSoftlineBreakAsHardlineBreak
+    {
+        get => (bool)GetValue(UseSoftlineBreakAsHardlineBreakProperty);
+        set => SetValue(UseSoftlineBreakAsHardlineBreakProperty, value);
+    }
+}

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers;
+using CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers.ObjectRenderers;
+using CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers.ObjectRenderers.Extensions;
+using CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers.ObjectRenderers.Inlines;
 using CommunityToolkit.Labs.WinUI.MarkdownTextBlock.TextElements;
 using Markdig;
 
@@ -13,7 +16,7 @@ public partial class MarkdownTextBlock : Control
 {
     private const string MarkdownContainerName = "MarkdownContainer";
     private Grid? _container;
-    private MarkdownPipeline _pipeline;
+    private MarkdownPipeline _pipeline = null!;
     private MyFlowDocument _document;
     private WinUIRenderer? _renderer;
 
@@ -42,6 +45,65 @@ public partial class MarkdownTextBlock : Control
         set => SetValue(TextProperty, value);
     }
 
+#region Built in Extensions
+
+    private static readonly DependencyProperty UseEmphasisExtrasProperty = DependencyProperty.Register(
+        nameof(UseEmphasisExtras),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+    public bool UseEmphasisExtras
+    {
+        get => (bool)GetValue(UseEmphasisExtrasProperty);
+        set => SetValue(UseEmphasisExtrasProperty, value);
+    }
+
+    private static readonly DependencyProperty UsePipeTablesProperty = DependencyProperty.Register(
+        nameof(UsePipeTables),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+    public bool UsePipeTables
+    {
+        get => (bool)GetValue(UsePipeTablesProperty);
+        set => SetValue(UsePipeTablesProperty, value);
+    }
+
+    private static readonly DependencyProperty UseListExtrasProperty = DependencyProperty.Register(
+        nameof(UseListExtras),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+    public bool UseListExtras
+    {
+        get => (bool)GetValue(UseListExtrasProperty);
+        set => SetValue(UseListExtrasProperty, value);
+    }
+
+    private static readonly DependencyProperty UseTaskListsProperty = DependencyProperty.Register(
+        nameof(UseTaskLists),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+    public bool UseTaskLists
+    {
+        get => (bool)GetValue(UseTaskListsProperty);
+        set => SetValue(UseTaskListsProperty, value);
+    }
+
+    private static readonly DependencyProperty UseAutoLinksProperty = DependencyProperty.Register(
+        nameof(UseAutoLinks),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+    public bool UseAutoLinks
+    {
+        get => (bool)GetValue(UseAutoLinksProperty);
+        set => SetValue(UseAutoLinksProperty, value);
+    }
+
+    #endregion
+
     private static void OnConfigChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is MarkdownTextBlock self && e.NewValue != null)
@@ -62,17 +124,23 @@ public partial class MarkdownTextBlock : Control
     {
         this.DefaultStyleKey = typeof(MarkdownTextBlock);
         _document = new MyFlowDocument();
-        _pipeline = new MarkdownPipelineBuilder()
-            .UseEmphasisExtras()
-            .UseAutoLinks()
-            .UseTaskLists()
-            .UsePipeTables()
-            .Build();
     }
 
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
+
+        var pipelineBuilder = new MarkdownPipelineBuilder();
+
+        // NOTE: Order matters here
+        if (UseEmphasisExtras) pipelineBuilder = pipelineBuilder.UseEmphasisExtras();
+        if (UsePipeTables) pipelineBuilder = pipelineBuilder.UsePipeTables();
+        if (UseListExtras) pipelineBuilder = pipelineBuilder.UseListExtras();
+        if (UseTaskLists) pipelineBuilder = pipelineBuilder.UseTaskLists();
+        if (UseAutoLinks) pipelineBuilder = pipelineBuilder.UseAutoLinks();
+
+        _pipeline = pipelineBuilder.Build();
+
         _container = (Grid)GetTemplateChild(MarkdownContainerName);
         _container.Children.Clear();
         _container.Children.Add(_document.RichTextBlock);
@@ -111,6 +179,31 @@ public partial class MarkdownTextBlock : Control
             if (_renderer == null)
             {
                 _renderer = new WinUIRenderer(_document, Config);
+
+                // Default block renderers
+                _renderer.ObjectRenderers.Add(new CodeBlockRenderer());
+                _renderer.ObjectRenderers.Add(new ListRenderer());
+                _renderer.ObjectRenderers.Add(new HeadingRenderer());
+                _renderer.ObjectRenderers.Add(new ParagraphRenderer());
+                _renderer.ObjectRenderers.Add(new QuoteBlockRenderer());
+                _renderer.ObjectRenderers.Add(new ThematicBreakRenderer());
+                _renderer.ObjectRenderers.Add(new HtmlBlockRenderer());
+
+                // Default inline renderers
+                if (UseAutoLinks) _renderer.ObjectRenderers.Add(new AutoLinkInlineRenderer());
+                _renderer.ObjectRenderers.Add(new CodeInlineRenderer());
+                _renderer.ObjectRenderers.Add(new DelimiterInlineRenderer());
+                _renderer.ObjectRenderers.Add(new EmphasisInlineRenderer());
+                _renderer.ObjectRenderers.Add(new HtmlEntityInlineRenderer());
+                _renderer.ObjectRenderers.Add(new LineBreakInlineRenderer());
+                _renderer.ObjectRenderers.Add(new LinkInlineRenderer());
+                _renderer.ObjectRenderers.Add(new LiteralInlineRenderer());
+                _renderer.ObjectRenderers.Add(new ContainerInlineRenderer());
+
+                // Extension renderers
+                if (UsePipeTables) _renderer.ObjectRenderers.Add(new TableRenderer());
+                if (UseTaskLists) _renderer.ObjectRenderers.Add(new TaskListRenderer());
+                _renderer.ObjectRenderers.Add(new HtmlInlineRenderer());
             }
             _pipeline.Setup(_renderer);
             ApplyText(false);

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
@@ -20,90 +20,6 @@ public partial class MarkdownTextBlock : Control
     private MyFlowDocument _document;
     private WinUIRenderer? _renderer;
 
-    private static readonly DependencyProperty ConfigProperty = DependencyProperty.Register(
-        nameof(Config),
-        typeof(MarkdownConfig),
-        typeof(MarkdownTextBlock),
-        new PropertyMetadata(null, OnConfigChanged)
-    );
-
-    private static readonly DependencyProperty TextProperty = DependencyProperty.Register(
-        nameof(Text),
-        typeof(string),
-        typeof(MarkdownTextBlock),
-        new PropertyMetadata(null, OnTextChanged));
-
-    public MarkdownConfig Config
-    {
-        get => (MarkdownConfig)GetValue(ConfigProperty);
-        set => SetValue(ConfigProperty, value);
-    }
-
-    public string Text
-    {
-        get => (string)GetValue(TextProperty);
-        set => SetValue(TextProperty, value);
-    }
-
-#region Built in Extensions
-
-    private static readonly DependencyProperty UseEmphasisExtrasProperty = DependencyProperty.Register(
-        nameof(UseEmphasisExtras),
-        typeof(bool),
-        typeof(MarkdownTextBlock),
-        new PropertyMetadata(false));
-    public bool UseEmphasisExtras
-    {
-        get => (bool)GetValue(UseEmphasisExtrasProperty);
-        set => SetValue(UseEmphasisExtrasProperty, value);
-    }
-
-    private static readonly DependencyProperty UsePipeTablesProperty = DependencyProperty.Register(
-        nameof(UsePipeTables),
-        typeof(bool),
-        typeof(MarkdownTextBlock),
-        new PropertyMetadata(false));
-    public bool UsePipeTables
-    {
-        get => (bool)GetValue(UsePipeTablesProperty);
-        set => SetValue(UsePipeTablesProperty, value);
-    }
-
-    private static readonly DependencyProperty UseListExtrasProperty = DependencyProperty.Register(
-        nameof(UseListExtras),
-        typeof(bool),
-        typeof(MarkdownTextBlock),
-        new PropertyMetadata(false));
-    public bool UseListExtras
-    {
-        get => (bool)GetValue(UseListExtrasProperty);
-        set => SetValue(UseListExtrasProperty, value);
-    }
-
-    private static readonly DependencyProperty UseTaskListsProperty = DependencyProperty.Register(
-        nameof(UseTaskLists),
-        typeof(bool),
-        typeof(MarkdownTextBlock),
-        new PropertyMetadata(false));
-    public bool UseTaskLists
-    {
-        get => (bool)GetValue(UseTaskListsProperty);
-        set => SetValue(UseTaskListsProperty, value);
-    }
-
-    private static readonly DependencyProperty UseAutoLinksProperty = DependencyProperty.Register(
-        nameof(UseAutoLinks),
-        typeof(bool),
-        typeof(MarkdownTextBlock),
-        new PropertyMetadata(false));
-    public bool UseAutoLinks
-    {
-        get => (bool)GetValue(UseAutoLinksProperty);
-        set => SetValue(UseAutoLinksProperty, value);
-    }
-
-    #endregion
-
     private static void OnConfigChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is MarkdownTextBlock self && e.NewValue != null)
@@ -138,6 +54,7 @@ public partial class MarkdownTextBlock : Control
         if (UseListExtras) pipelineBuilder = pipelineBuilder.UseListExtras();
         if (UseTaskLists) pipelineBuilder = pipelineBuilder.UseTaskLists();
         if (UseAutoLinks) pipelineBuilder = pipelineBuilder.UseAutoLinks();
+        if (UseSoftlineBreakAsHardlineBreak) pipelineBuilder = pipelineBuilder.UseSoftlineBreakAsHardlineBreak();
 
         _pipeline = pipelineBuilder.Build();
 

--- a/components/MarkdownTextBlock/src/Renderers/WinUIRenderer.cs
+++ b/components/MarkdownTextBlock/src/Renderers/WinUIRenderer.cs
@@ -31,12 +31,6 @@ public class WinUIRenderer : RendererBase
         FlowDocument = document;
         // set style
         _stack.Push(FlowDocument);
-        LoadOverridenRenderers();
-    }
-
-    private void LoadOverridenRenderers()
-    {
-        LoadRenderers();
     }
 
     public override object Render(MarkdownObject markdownObject)
@@ -50,7 +44,6 @@ public class WinUIRenderer : RendererBase
         _stack.Clear();
         FlowDocument.RichTextBlock.Blocks.Clear();
         _stack.Push(FlowDocument);
-        LoadOverridenRenderers();
     }
 
     public void WriteLeafInline(LeafBlock leafBlock)
@@ -142,33 +135,5 @@ public class WinUIRenderer : RendererBase
     private static void AddInline(IAddChild parent, IAddChild inline)
     {
         parent.AddChild(inline);
-    }
-
-    protected virtual void LoadRenderers()
-    {
-        // Default block renderers
-        ObjectRenderers.Add(new CodeBlockRenderer());
-        ObjectRenderers.Add(new ListRenderer());
-        ObjectRenderers.Add(new HeadingRenderer());
-        ObjectRenderers.Add(new ParagraphRenderer());
-        ObjectRenderers.Add(new QuoteBlockRenderer());
-        ObjectRenderers.Add(new ThematicBreakRenderer());
-        ObjectRenderers.Add(new HtmlBlockRenderer());
-
-        // Default inline renderers
-        ObjectRenderers.Add(new AutoLinkInlineRenderer());
-        ObjectRenderers.Add(new CodeInlineRenderer());
-        ObjectRenderers.Add(new DelimiterInlineRenderer());
-        ObjectRenderers.Add(new EmphasisInlineRenderer());
-        ObjectRenderers.Add(new HtmlEntityInlineRenderer());
-        ObjectRenderers.Add(new LineBreakInlineRenderer());
-        ObjectRenderers.Add(new LinkInlineRenderer());
-        ObjectRenderers.Add(new LiteralInlineRenderer());
-        ObjectRenderers.Add(new ContainerInlineRenderer());
-
-        // Extension renderers
-        ObjectRenderers.Add(new TableRenderer());
-        ObjectRenderers.Add(new TaskListRenderer());
-        ObjectRenderers.Add(new HtmlInlineRenderer());
     }
 }


### PR DESCRIPTION
First step to making MarkdownTextBlock extensions configurable. Makes built-in Markdig extensions that have been implemented in the renderer configurable via properties. They are all `false` by default, but I'm open to changing that.

Adds the following properties:

- UseAutoLinks
- UseEmphasisExtras
- UseListExtras
- UsePipeTables
- UseTaskLists

Example
```xaml
<controls:MarkdownTextBlock
  Grid.Row="3"
  Config="{x:Bind MarkdownConfig, Mode=OneTime}"
  Text="{x:Bind Text, Mode=OneTime}"
  UseAutoLinks="True"
  UseEmphasisExtras="True"
  UseListExtras="True"
  UsePipeTables="True"
  UseTaskLists="True" />
```