### PR TITLE
MarkdownTextBlock: Minor style improvements

### DIFF
--- a/components/MarkdownTextBlock/src/TextElements/MyHeading.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyHeading.cs
@@ -47,6 +47,7 @@ internal class MyHeading : IAddChild
             5 => _config.Themes.H5FontWeight,
             _ => _config.Themes.H6FontWeight,
         };
+        _paragraph.Margin = new Thickness(left: 0, top: 14, right: 0, bottom: 0);
     }
 
     public MyHeading(HtmlNode htmlNode, MarkdownConfig config)

--- a/components/MarkdownTextBlock/src/TextElements/MyList.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyList.cs
@@ -45,6 +45,7 @@ internal class MyList : IAddChild
         }
 
         _stackPanel.Orientation = Orientation.Vertical;
+        _stackPanel.Margin = new Thickness(left: 0, top: 8, right: 0, bottom: 8);
         _container.Child = _stackPanel;
         _paragraph.Inlines.Add(_container);
     }
@@ -52,7 +53,8 @@ internal class MyList : IAddChild
     public void AddChild(IAddChild child)
     {
         var grid = new Grid();
-        grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Auto) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(20, GridUnitType.Pixel) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(10, GridUnitType.Pixel) });
         grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
         string bullet;
         if (_isOrdered)
@@ -79,11 +81,12 @@ internal class MyList : IAddChild
         };
         textBlock.SetValue(Grid.ColumnProperty, 0);
         textBlock.VerticalAlignment = VerticalAlignment.Top;
+        textBlock.TextAlignment = TextAlignment.Right;
         grid.Children.Add(textBlock);
         var flowDoc = new MyFlowDocument();
         flowDoc.AddChild(child);
 
-        flowDoc.RichTextBlock.SetValue(Grid.ColumnProperty, 1);
+        flowDoc.RichTextBlock.SetValue(Grid.ColumnProperty, 2);
         flowDoc.RichTextBlock.Padding = new Thickness(0);
         flowDoc.RichTextBlock.VerticalAlignment = VerticalAlignment.Top;
         grid.Children.Add(flowDoc.RichTextBlock);

--- a/components/MarkdownTextBlock/src/TextElements/MyThematicBreak.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyThematicBreak.cs
@@ -22,14 +22,14 @@ internal class MyThematicBreak : IAddChild
         _paragraph = new Paragraph();
 
         var inlineUIContainer = new InlineUIContainer();
-        var border = new Border();
-        border.Width = 500;
-        border.BorderThickness = new Thickness(1);
-        border.Margin = new Thickness(0, 4, 0, 4);
-        border.BorderBrush = new SolidColorBrush(Colors.Gray);
-        border.Height = 1;
-        border.HorizontalAlignment = HorizontalAlignment.Stretch;
-        inlineUIContainer.Child = border;
+        Line line = new Line
+        {
+            Stretch = Stretch.Fill,
+            Stroke = new SolidColorBrush(Colors.Gray),
+            X2 = 1,
+            Margin = new Thickness(0, 12, 0, 12)
+        };
+        inlineUIContainer.Child = line;
         _paragraph.Inlines.Add(inlineUIContainer);
     }
 


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/88cb30e1-bd54-4eda-9884-3676b2b9ec27)

After:

![image](https://github.com/user-attachments/assets/09ebcf39-5029-48b5-8f77-cc0d6db526e9)

Changes:
- Lists have proper margins before and after
- List item bullets have proper padding and are right-aligned to the column
- Thematic breaks now have 100% width rather than hard-coded to 500px
- Headings now have proper margins before