### PR TITLE
Specify directory for dotnet to install to and execute from

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ on:
 
 env:
   DOTNET_VERSION: ${{ '8.0.201' }}
+  DOTNET_INSTALL_DIR: dotnet-install
+  DOTNET_ROOT: dotnet-install
   ENABLE_DIAGNOSTICS: false
   #COREHOST_TRACE: 1
   MSBUILD_VERBOSITY: normal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,10 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);Uno0001</NoWarn> 
+    <NoWarn>$(NoWarn);Uno0001</NoWarn>
+
+    <!-- See https://github.com/CommunityToolkit/Labs-Windows/pull/605#issuecomment-2498743676 -->
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <Import Project="Windows.Toolkit.Common.props" />


### PR DESCRIPTION
This PR attempts fix the ongoing CI errors caused by GitHub Actions updating the image to include net9.0 unexpectedly. 

This setup forces only the specified dotnet version to be available when `dotnet --list-sdks` is run, avoiding the errors caused by the introduction of dotnet 9 and unblocking us while we work to resolve them in https://github.com/CommunityToolkit/Windows/pull/563.  