### PR TITLE
MarkdownTextBlock: Adds OnMarkdownParsed event

### DIFF
--- a/components/MarkdownTextBlock/src/MarkdownParsedEventArgs.cs
+++ b/components/MarkdownTextBlock/src/MarkdownParsedEventArgs.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Markdig.Syntax;
+
+namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+
+public sealed class MarkdownParsedEventArgs : EventArgs
+{
+    public MarkdownDocument Document { get; }
+    public MarkdownParsedEventArgs(MarkdownDocument document)
+    {
+        Document = document;
+    }
+}

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.Events.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.Events.cs
@@ -13,6 +13,7 @@ partial class MarkdownTextBlock
 
     /// <summary>
     /// Event raised when markdown is done parsing, with a complete MarkdownDocument.
+    /// It is always raised before the control renders the document.
     /// </summary>
     public event EventHandler<MarkdownParsedEventArgs>? OnMarkdownParsed;
 }

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.Events.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.Events.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+
+partial class MarkdownTextBlock
+{
+    /// <summary>
+    /// Event raised when a markdown link is clicked.
+    /// </summary>
+    public event EventHandler<LinkClickedEventArgs>? OnLinkClicked;
+
+    /// <summary>
+    /// Event raised when markdown is done parsing, with a complete MarkdownDocument.
+    /// </summary>
+    public event EventHandler<MarkdownParsedEventArgs>? OnMarkdownParsed;
+}

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
@@ -55,8 +55,6 @@ public partial class MarkdownTextBlock : Control
         private set => SetValue(MarkdownDocumentProperty, value);
     }
 
-    public event EventHandler<LinkClickedEventArgs>? OnLinkClicked;
-
     internal void RaiseLinkClickedEvent(Uri uri) => OnLinkClicked?.Invoke(this, new LinkClickedEventArgs(uri));
 
     private static void OnConfigChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -116,6 +114,7 @@ public partial class MarkdownTextBlock : Control
             if (!string.IsNullOrEmpty(Text))
             {
                 this.MarkdownDocument = Markdown.Parse(Text, _pipeline);
+                OnMarkdownParsed?.Invoke(this, new MarkdownParsedEventArgs(this.MarkdownDocument));
                 _renderer.Render(this.MarkdownDocument);
             }
         }


### PR DESCRIPTION
Adds an event `MarkdownTextBlock.OnMarkdownParsed`, which is useful because consumers cannot otherwise know when the MarkdownDocument has finished being generated from the markdown text input. It also technically allows consumers to mutate the markdown parsed tree *before* the render step takes place.