### PR TITLE
Fix packaging for AppServices

### DIFF
--- a/components/AppServices/src/CommunityToolkit.AppServices.csproj
+++ b/components/AppServices/src/CommunityToolkit.AppServices.csproj
@@ -53,7 +53,7 @@
     <None Include="CommunityToolkit.Labs.AppServices.targets" PackagePath="build" Pack="true" />
 
     <!-- Pack the source generator to the right package folder -->
-    <None Include="..\CommunityToolkit.AppServices.SourceGenerators\bin\$(Platform)\$(Configuration)\netstandard2.0\CommunityToolkit.AppServices.SourceGenerators.dll" PackagePath="analyzers\dotnet\cs" Pack="true" Visible="false" />
+    <None Include="..\CommunityToolkit.AppServices.SourceGenerators\bin\$(Configuration)\netstandard2.0\CommunityToolkit.AppServices.SourceGenerators.dll" PackagePath="analyzers\dotnet\cs" Pack="true" Visible="false" />
   </ItemGroup>
 
   <!-- Remove imported global usings -->


### PR DESCRIPTION
This PR makes a minor change that fixes packaging issues we were seeing with the AppServices component.

Closes #623
Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/244