### PR TITLE
Enabled diagnostics for binlog output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   DOTNET_VERSION: ${{ '9.0.x' }}
-  ENABLE_DIAGNOSTICS: false
+  ENABLE_DIAGNOSTICS: true
   #COREHOST_TRACE: 1
   MSBUILD_VERBOSITY: normal
   COREHOST_TRACEFILE: corehosttrace.log


### PR DESCRIPTION
This PR enables the diagnostic flag in our CI, matching the https://github.com/CommunityToolkit/Windows/blob/3ae977111da585c8d2172d4f0f65012d5254321e/.github/workflows/build.yml#L21. 

This is needed to enable binlog outputs in the Package step, to investigate ongoing issues with the AppServices package.