### PR TITLE
Fix sudden CI errors

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "uno.check": {
-      "version": "1.20.2",
+      "version": "1.27.4",
       "commands": [
         "uno-check"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <NoWarn>$(NoWarn);Uno0001</NoWarn>
 
     <!-- See https://github.com/CommunityToolkit/Labs-Windows/pull/605#issuecomment-2498743676 -->
-    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CS1591;CS1574</WarningsNotAsErrors>
   </PropertyGroup>
 
   <Import Project="Windows.Toolkit.Common.props" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,13 @@
     <NoWarn>$(NoWarn);Uno0001</NoWarn>
 
     <!-- See https://github.com/CommunityToolkit/Labs-Windows/pull/605#issuecomment-2498743676 -->
-    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CS1591;CS1574</WarningsNotAsErrors>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;</WarningsNotAsErrors>
+
+    <!-- Labs only: No error for 'Missing XML comment for publicly visible type or member' -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591;CS1574;</WarningsNotAsErrors>
+
+    <!-- See https://github.com/CommunityToolkit/Windows/pull/609#issuecomment-2613505591 -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0419;CS1570;</WarningsNotAsErrors>
   </PropertyGroup>
 
   <Import Project="Windows.Toolkit.Common.props" />

--- a/components/MarkdownTextBlock/src/TextElements/MyList.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyList.cs
@@ -96,7 +96,7 @@ internal class MyList : IAddChild
 
     private BulletType ToBulletType(char bullet)
     {
-        /// Gets or sets the type of the bullet (e.g: '1', 'a', 'A', 'i', 'I').
+        // Gets or sets the type of the bullet (e.g: '1', 'a', 'A', 'i', 'I').
         switch (bullet)
         {
             case '1':

--- a/components/RivePlayer/src/StateMachineInputCollection.cs
+++ b/components/RivePlayer/src/StateMachineInputCollection.cs
@@ -11,7 +11,7 @@ namespace CommunityToolkit.Labs.WinUI.Rive;
 ///
 ///   <rive:RivePlayer Source="...">
 ///       <!--  Adds this input to the StateMachineInputCollection.  -->
-///       <rive:BoolInput Target=... />
+///       <rive:BoolInput Target="..." />
 ///   </rive:RivePlayer>
 ///
 /// </summary>


### PR DESCRIPTION
This PR
- Fixes several errors related to missing XMLDoc comments.
- Updates our uno.check version to the latest 1.27.4
- Attempts unblock our CI

Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/249