### PR TITLE
🚧 Add SBOM generation to NuGet Package output using Microsoft.Sbom.Targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <GenerateSBOM>true</GenerateSBOM>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);Uno0001</NoWarn>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,8 +5,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.1" PrivateAssets="all" />
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="6.12.1" PrivateAssets="all" Pack="false" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Initial attempt at adding SBOMs to our NuGet Packages.

Following https://www.meziantou.net/generating-sbom-for-nuget-packages.htm

Package Listing: https://www.nuget.org/packages/Microsoft.Sbom.Targets
Tool repo: https://github.com/microsoft/sbom-tool

Package/Tool Source: https://github.com/microsoft/sbom-tool/tree/main/src/Microsoft.Sbom.Targets