### PR TITLE
Add support for requesting WinUI 0 (non-WinUI) components be build. For use by packaging CI matrix.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
       matrix:
-        winui: [2, 3]
+        winui: [0, 2, 3]
 
     env:
       VERSION_PROPERTY: ${{ github.ref == 'refs/heads/main' && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
@@ -256,20 +256,10 @@ jobs:
         uses: microsoft/setup-msbuild@v2
         with:
           vs-version: '[17.9,)'
-
-      - name: Define excluded MultiTargets (WinUI 2)
-        if: ${{ matrix.winui == '2' }}
-        run: |
-          echo "EXCLUDED_MULTITARGETS=wasdk" >> $env:GITHUB_ENV
-
-      - name: Define excluded MultiTargets (WinUI 3)
-        if: ${{ matrix.winui == '3' }}
-        run: |
-          echo "EXCLUDED_MULTITARGETS=uwp" >> $env:GITHUB_ENV
           
       # Build and pack component nupkg
       - name: Build and pack component packages
-        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -ExcludeMultiTargets ${{ env.EXCLUDED_MULTITARGETS }} -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
+        run: ./tooling/Build-Toolkit-Components.ps1 -MultiTargets all -WinUIMajorVersion ${{ matrix.winui }} -DateForVersion ${{ env.VERSION_DATE }} ${{ env.VERSION_PROPERTY != '' && format('-PreviewVersion "{0}"', env.VERSION_PROPERTY) || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-EnableBinlogs' || '' }} ${{ env.ENABLE_DIAGNOSTICS == 'true' && '-Verbose' || '' }} -BinlogOutput ./ -NupkgOutput ./ -Release
 
       - name: Validate package names
         if: ${{ env.VERSION_PROPERTY != '' }}


### PR DESCRIPTION
This PR:
- Introduces the concept of "WinUI 0" as possible parameter in our `Build-Toolkit-Components.ps1` script, indicating that non-WinUI projects should be built.
- Fixes the "skip building component" logic for WinUI 2 and 3 projects
- Allows consuming repositories (Labs, mainline WCT) to build and package WinUI 0, 2 and 3 components concurrently in CI without race conditions or improperly skipped components.

Prerequisite PR: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/258