### PR TITLE
Fix solution generation issues by updating slngen

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "11.2.6",
+      "version": "12.0.13",
       "commands": [
         "slngen"
       ]


### PR DESCRIPTION
This PR fixes build errors that spontaneously occurred when generating the solution, likely due to a tooling update. Updating slngen to the lates version fixes the issue.