### PR TITLE
Update DI generator for lazy-init, better codegen

### DIFF
--- a/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/Models/RegisteredServiceInfo.cs
+++ b/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/Models/RegisteredServiceInfo.cs
@@ -10,11 +10,13 @@ namespace CommunityToolkit.Extensions.DependencyInjection.SourceGenerators.Model
 /// A model for a singleton service registration.
 /// </summary>
 /// <param name="RegistrationKind">The registration kind for the service.</param>
+/// <param name="ImplementationTypeName">The type name of the implementation type.</param>
 /// <param name="ImplementationFullyQualifiedTypeName">The fully qualified type name of the implementation type.</param>
 /// <param name="RequiredServiceFullyQualifiedTypeNames">The fully qualified type names of dependent services for <paramref name="ImplementationFullyQualifiedTypeName"/>.</param>
 /// <param name="ServiceFullyQualifiedTypeNames">The fully qualified type names for the services to register for <paramref name="ImplementationFullyQualifiedTypeName"/>.</param>
 internal sealed record RegisteredServiceInfo(
     ServiceRegistrationKind RegistrationKind,
+    string ImplementationTypeName,
     string ImplementationFullyQualifiedTypeName,
     EquatableArray<string> RequiredServiceFullyQualifiedTypeNames,
     EquatableArray<string> ServiceFullyQualifiedTypeNames);

--- a/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/ServiceProviderGenerator.Execute.cs
+++ b/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/ServiceProviderGenerator.Execute.cs
@@ -222,7 +222,7 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
                     .AddModifiers(Token(SyntaxKind.StaticKeyword))
                     .AddParameterListParameters(
                         Parameter(Identifier("services"))
-                        .WithType(IdentifierName("global::System.IserviceProvider")))
+                        .WithType(IdentifierName("global::System.IServiceProvider")))
                     .AddBodyStatements(
                         ReturnStatement(
                             ObjectCreationExpression(IdentifierName(serviceInfo.ImplementationFullyQualifiedTypeName))

--- a/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/ServiceProviderGenerator.Execute.cs
+++ b/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/ServiceProviderGenerator.Execute.cs
@@ -254,7 +254,7 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
                 {
                     // Register the main implementation type:
                     //
-                    // global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.<REGISTRATION_METHOD>(<PARAMETER_NAME>, typeof(<DEPENDENT_SERVICE_TYPE>), new global::System.Action<global::Microsoft.Extensions.DependencyInjection.IServiceCollection, object>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredServices<ROOT_SERVICE_TYPE>));
+                    // global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.<REGISTRATION_METHOD>(<PARAMETER_NAME>, typeof(<DEPENDENT_SERVICE_TYPE>), new global::System.Func<global::System.IServiceProvider, object>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredServices<ROOT_SERVICE_TYPE>));
                     registrationStatements.Add(
                         ExpressionStatement(
                             InvocationExpression(
@@ -267,9 +267,9 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
                                 Argument(TypeOfExpression(IdentifierName(dependentServiceType))),
                                 Argument(
                                     ObjectCreationExpression(
-                                        GenericName("global::System.Action")
+                                        GenericName("global::System.Func")
                                         .AddTypeArgumentListArguments(
-                                            IdentifierName("global::Microsoft.Extensions.DependencyInjection.IServiceCollection"),
+                                            IdentifierName("global::System.IServiceProvider"),
                                             PredefinedType(Token(SyntaxKind.ObjectKeyword))))
                                     .AddArgumentListArguments(Argument(
                                         MemberAccessExpression(

--- a/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/ServiceProviderGenerator.Execute.cs
+++ b/components/Extensions.DependencyInjection/CommunityToolkit.Extensions.DependencyInjection.SourceGenerators/ServiceProviderGenerator.Execute.cs
@@ -143,6 +143,7 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
                     // Create the model fully describing the current service registration
                     serviceInfo.Add(new RegisteredServiceInfo(
                         RegistrationKind: registrationKind,
+                        ImplementationTypeName: implementationType.Name,
                         ImplementationFullyQualifiedTypeName: implementationTypeName,
                         ServiceFullyQualifiedTypeNames: serviceTypeNames,
                         RequiredServiceFullyQualifiedTypeNames: constructorArgumentTypes));
@@ -166,7 +167,10 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
         /// <returns>A <see cref="CompilationUnitSyntax"/> instance with the gathered info.</returns>
         public static CompilationUnitSyntax GetSyntax(ServiceCollectionInfo info)
         {
+            using ImmutableArrayBuilder<LocalFunctionStatementSyntax> localFunctions = ImmutableArrayBuilder<LocalFunctionStatementSyntax>.Rent();
             using ImmutableArrayBuilder<StatementSyntax> registrationStatements = ImmutableArrayBuilder<StatementSyntax>.Rent();
+
+            int index = -1;
 
             foreach (RegisteredServiceInfo serviceInfo in info.Services)
             {
@@ -175,6 +179,9 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
                 {
                     continue;
                 }
+
+                // Increment the index we use to disambiguate the generated local function names (starting from 0)
+                index++;
 
                 using ImmutableArrayBuilder<ArgumentSyntax> constructorArguments = ImmutableArrayBuilder<ArgumentSyntax>.Rent();
 
@@ -199,47 +206,48 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
                 // Prepare the method name, either AddSingleton or AddTransient
                 string registrationMethod = $"Add{serviceInfo.RegistrationKind}";
 
-                // Special case when the service is a singleton and no dependent services are present, we can use the parameterless constructor
+                // Prepare the name of the factory local function
+                string factoryMethod = $"Get{serviceInfo.ImplementationTypeName}_{index}";
+
+                // Prepare the local function for the registration (to improve lambda caching):
                 //
-                // global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton(<PARAMETER_NAME>, typeof(<ROOT_SERVICE_TYPE>), static _ => new <IMPLEMENTATION_TYPE>());
-                if (serviceInfo.RegistrationKind == ServiceRegistrationKind.Singleton && constructorArguments.Count == 0)
-                {
-                    registrationStatements.Add(
-                        ExpressionStatement(
-                            InvocationExpression(
-                                MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
-                                    IdentifierName("global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions"),
-                                    IdentifierName("AddSingleton")))
-                            .AddArgumentListArguments(
-                                Argument(IdentifierName(info.Method.ServiceCollectionParameterName)),
-                                Argument(TypeOfExpression(IdentifierName(rootServiceTypeName))),
-                                Argument(
-                                    ObjectCreationExpression(IdentifierName(serviceInfo.ImplementationFullyQualifiedTypeName))
-                                    .WithArgumentList(ArgumentList())))));
-                }
-                else
-                {
-                    // Register the main implementation type when at least a dependent service is needed:
-                    //
-                    // global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.<REGISTRATION_METHOD>(<PARAMETER_NAME>, typeof(<ROOT_SERVICE_TYPE>), static services => new <IMPLEMENTATION_TYPE>(<CONSTRUCTOR_ARGUMENTS>));
-                    registrationStatements.Add(
-                        ExpressionStatement(
-                            InvocationExpression(
-                                MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
-                                    IdentifierName("global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions"),
-                                    IdentifierName(registrationMethod)))
-                            .AddArgumentListArguments(
-                                Argument(IdentifierName(info.Method.ServiceCollectionParameterName)),
-                                Argument(TypeOfExpression(IdentifierName(rootServiceTypeName))),
-                                Argument(
-                                    SimpleLambdaExpression(Parameter(Identifier("services")))
-                                    .AddModifiers(Token(SyntaxKind.StaticKeyword))
-                                    .WithExpressionBody(
-                                        ObjectCreationExpression(IdentifierName(serviceInfo.ImplementationFullyQualifiedTypeName))
-                                        .AddArgumentListArguments(constructorArguments.ToArray()))))));
-                }
+                // static object <FACTORY_METHOD>(global::System.IServiceProvider services)
+                // {
+                //     return new <IMPLEMENTATION_TYPE>(<CONSTRUCTOR_ARGUMENTS>);
+                // }
+                localFunctions.Add(
+                    LocalFunctionStatement(
+                        PredefinedType(Token(SyntaxKind.ObjectKeyword)),
+                        Identifier(factoryMethod))
+                    .AddModifiers(Token(SyntaxKind.StaticKeyword))
+                    .AddParameterListParameters(
+                        Parameter(Identifier("services"))
+                        .WithType(IdentifierName("global::System.IserviceProvider")))
+                    .AddBodyStatements(
+                        ReturnStatement(
+                            ObjectCreationExpression(IdentifierName(serviceInfo.ImplementationFullyQualifiedTypeName))
+                            .AddArgumentListArguments(constructorArguments.ToArray()))));
+
+                // Register the main implementation type:
+                //
+                // global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.<REGISTRATION_METHOD>(<PARAMETER_NAME>, typeof(<ROOT_SERVICE_TYPE>), new global::Func<global::System.IServiceProvider, object>(<FACTORY_METHOD>));
+                registrationStatements.Add(
+                    ExpressionStatement(
+                        InvocationExpression(
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                IdentifierName("global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions"),
+                                IdentifierName(registrationMethod)))
+                        .AddArgumentListArguments(
+                            Argument(IdentifierName(info.Method.ServiceCollectionParameterName)),
+                            Argument(TypeOfExpression(IdentifierName(rootServiceTypeName))),
+                            Argument(
+                                ObjectCreationExpression(
+                                    GenericName(Identifier("global::System.Func"))
+                                    .AddTypeArgumentListArguments(
+                                        IdentifierName("global::System.IServiceProvider"),
+                                        PredefinedType(Token(SyntaxKind.ObjectKeyword))))
+                                .AddArgumentListArguments(Argument(IdentifierName(factoryMethod)))))));
 
                 // Register all secondary services, if any
                 foreach (string dependentServiceType in dependentServiceTypeNames)
@@ -295,6 +303,7 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
             // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
             // <MODIFIERS> <RETURN_TYPE> <METHOD_NAME>(global::Microsoft.Extensions.DependencyInjection.IServiceCollection <PARAMETER_NAME>)
             // {
+            //     <LOCAL_FUNCTIONS>
             //     <REGISTRATION_STATEMENTS>
             // }
             MethodDeclarationSyntax configureServicesMethodDeclaration =
@@ -303,6 +312,7 @@ partial class ServiceProviderGenerator : IIncrementalGenerator
                 .AddParameterListParameters(
                     Parameter(Identifier(info.Method.ServiceCollectionParameterName))
                     .WithType(IdentifierName("global::Microsoft.Extensions.DependencyInjection.IServiceCollection")))
+                .AddBodyStatements(localFunctions.ToArray())
                 .AddBodyStatements(registrationStatements.ToArray())
                 .AddAttributeLists(
                     AttributeList(SingletonSeparatedList(


### PR DESCRIPTION
This PR updates the DI generator with the following changes:
- Always registers all services as lazy-init, for consistency
  - We can add some option to make this opt-out in the future, if needed
- Improve the codegen of all registration stubs