### PR TITLE
Align RootNamespace across tests to remove "Experiment" suffix

### DIFF
--- a/components/AppServices/tests/AppServices.Tests.projitems
+++ b/components/AppServices/tests/AppServices.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>A3106AE5-5AA9-4307-9041-E9C4232AA7F2</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>AppServices.Tests</Import_RootNamespace>
+    <Import_RootNamespace>AppServicesTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/AppServices/tests/AppServices.Tests.projitems
+++ b/components/AppServices/tests/AppServices.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>A3106AE5-5AA9-4307-9041-E9C4232AA7F2</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>AppServicesExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>AppServices.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/CanvasLayout/tests/CanvasLayout.Tests.projitems
+++ b/components/CanvasLayout/tests/CanvasLayout.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>A09DC4AC-4111-440E-A188-E787CAE8C0B1</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>CanvasLayout.Tests</Import_RootNamespace>
+    <Import_RootNamespace>CanvasLayoutTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleCanvasLayoutTestClass.cs" />

--- a/components/CanvasLayout/tests/CanvasLayout.Tests.projitems
+++ b/components/CanvasLayout/tests/CanvasLayout.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>A09DC4AC-4111-440E-A188-E787CAE8C0B1</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>CanvasLayoutExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>CanvasLayout.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleCanvasLayoutTestClass.cs" />

--- a/components/CanvasLayout/tests/ExampleCanvasLayoutTestClass.cs
+++ b/components/CanvasLayout/tests/ExampleCanvasLayoutTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace CanvasLayoutExperiment.Tests;
+namespace CanvasLayout.Tests;
 
 [TestClass]
 public partial class ExampleCanvasLayoutTestClass : VisualUITestBase

--- a/components/CanvasLayout/tests/ExampleCanvasLayoutTestClass.cs
+++ b/components/CanvasLayout/tests/ExampleCanvasLayoutTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace CanvasLayout.Tests;
+namespace CanvasLayoutTests;
 
 [TestClass]
 public partial class ExampleCanvasLayoutTestClass : VisualUITestBase

--- a/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml
+++ b/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="CanvasLayoutExperiment.Tests.ExampleCanvasLayoutTestPage"
+<Page x:Class="CanvasLayout.Tests.ExampleCanvasLayoutTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml
+++ b/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="CanvasLayout.Tests.ExampleCanvasLayoutTestPage"
+<Page x:Class="CanvasLayoutTests.ExampleCanvasLayoutTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml.cs
+++ b/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CanvasLayoutExperiment.Tests;
+namespace CanvasLayout.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml.cs
+++ b/components/CanvasLayout/tests/ExampleCanvasLayoutTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CanvasLayout.Tests;
+namespace CanvasLayoutTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/CanvasView/tests/CanvasView.Tests.projitems
+++ b/components/CanvasView/tests/CanvasView.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>33D731BA-A745-418B-BF4A-BD8FB9880918</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>CanvasView.Tests</Import_RootNamespace>
+    <Import_RootNamespace>CanvasViewTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleCanvasViewTestClass.cs" />

--- a/components/CanvasView/tests/CanvasView.Tests.projitems
+++ b/components/CanvasView/tests/CanvasView.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>33D731BA-A745-418B-BF4A-BD8FB9880918</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>CanvasViewExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>CanvasView.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleCanvasViewTestClass.cs" />

--- a/components/CanvasView/tests/ExampleCanvasViewTestClass.cs
+++ b/components/CanvasView/tests/ExampleCanvasViewTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace CanvasView.Tests;
+namespace CanvasViewTests;
 
 [TestClass]
 public partial class ExampleCanvasViewTestClass : VisualUITestBase

--- a/components/CanvasView/tests/ExampleCanvasViewTestClass.cs
+++ b/components/CanvasView/tests/ExampleCanvasViewTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace CanvasViewExperiment.Tests;
+namespace CanvasView.Tests;
 
 [TestClass]
 public partial class ExampleCanvasViewTestClass : VisualUITestBase

--- a/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml
+++ b/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="CanvasView.Tests.ExampleCanvasViewTestPage"
+<Page x:Class="CanvasViewTests.ExampleCanvasViewTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml
+++ b/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="CanvasViewExperiment.Tests.ExampleCanvasViewTestPage"
+<Page x:Class="CanvasView.Tests.ExampleCanvasViewTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml.cs
+++ b/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CanvasView.Tests;
+namespace CanvasViewTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml.cs
+++ b/components/CanvasView/tests/ExampleCanvasViewTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CanvasViewExperiment.Tests;
+namespace CanvasView.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/DataTable/tests/DataTable.Tests.projitems
+++ b/components/DataTable/tests/DataTable.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>758CD4BC-2E2C-4FAD-8C96-BD73E0EF128B</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>DataTableExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>DataTable.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)DataTableLayoutTestClass.cs" />

--- a/components/DataTable/tests/DataTable.Tests.projitems
+++ b/components/DataTable/tests/DataTable.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>758CD4BC-2E2C-4FAD-8C96-BD73E0EF128B</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>DataTable.Tests</Import_RootNamespace>
+    <Import_RootNamespace>DataTableTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)DataTableLayoutTestClass.cs" />

--- a/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml
+++ b/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="DataTable.Tests.DataTableColumnAutoSizeTestPage"
+<Page x:Class="DataTableTests.DataTableColumnAutoSizeTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml
+++ b/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="DataTableExperiment.Tests.DataTableColumnAutoSizeTestPage"
+<Page x:Class="DataTable.Tests.DataTableColumnAutoSizeTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml.cs
+++ b/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace DataTableExperiment.Tests;
+namespace DataTable.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml.cs
+++ b/components/DataTable/tests/DataTableColumnAutoSizeTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace DataTable.Tests;
+namespace DataTableTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/DataTable/tests/DataTableLayoutTestClass.cs
+++ b/components/DataTable/tests/DataTableLayoutTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace DataTableExperiment.Tests;
+namespace DataTable.Tests;
 
 /// <summary>
 /// Class for testing various aspects of layout in relation to DataTable components.

--- a/components/DataTable/tests/DataTableLayoutTestClass.cs
+++ b/components/DataTable/tests/DataTableLayoutTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace DataTable.Tests;
+namespace DataTableTests;
 
 /// <summary>
 /// Class for testing various aspects of layout in relation to DataTable components.

--- a/components/DependencyPropertyGenerator/tests/DependencyPropertyGenerator.Tests.projitems
+++ b/components/DependencyPropertyGenerator/tests/DependencyPropertyGenerator.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>22BE50B3-9810-4304-899E-6D7AF9D3147A</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>DependencyPropertyGeneratorExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>DependencyPropertyGenerator.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/DependencyPropertyGenerator/tests/DependencyPropertyGenerator.Tests.projitems
+++ b/components/DependencyPropertyGenerator/tests/DependencyPropertyGenerator.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>22BE50B3-9810-4304-899E-6D7AF9D3147A</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>DependencyPropertyGenerator.Tests</Import_RootNamespace>
+    <Import_RootNamespace>DependencyPropertyGeneratorTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/Extensions.DependencyInjection/tests/Extensions.DependencyInjection.Tests.projitems
+++ b/components/Extensions.DependencyInjection/tests/Extensions.DependencyInjection.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>47BFA618-6EF6-426A-B7CB-D8F2CEA68302</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Extensions.DependencyInjectionExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Extensions.DependencyInjection.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestClass.cs
+++ b/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
 
-namespace MarkdownTextBlock.Tests;
+namespace MarkdownTextBlockTests;
 
 [TestClass]
 public partial class ExampleMarkdownTextBlockTestClass : VisualUITestBase

--- a/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestClass.cs
+++ b/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
 
-namespace MarkdownTextBlockExperiment.Tests;
+namespace MarkdownTextBlock.Tests;
 
 [TestClass]
 public partial class ExampleMarkdownTextBlockTestClass : VisualUITestBase

--- a/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml
+++ b/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="MarkdownTextBlockExperiment.Tests.ExampleMarkdownTextBlockTestPage"
+<Page x:Class="MarkdownTextBlock.Tests.ExampleMarkdownTextBlockTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"

--- a/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml
+++ b/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="MarkdownTextBlock.Tests.ExampleMarkdownTextBlockTestPage"
+<Page x:Class="MarkdownTextBlockTests.ExampleMarkdownTextBlockTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"

--- a/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml.cs
+++ b/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace MarkdownTextBlock.Tests;
+namespace MarkdownTextBlockTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml.cs
+++ b/components/MarkdownTextBlock/tests/ExampleMarkdownTextBlockTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace MarkdownTextBlockExperiment.Tests;
+namespace MarkdownTextBlock.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/MarkdownTextBlock/tests/MarkdownTextBlock.Tests.projitems
+++ b/components/MarkdownTextBlock/tests/MarkdownTextBlock.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>6F0FA793-7CF0-41F9-B7D9-260039B62C8A</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>MarkdownTextBlock.Tests</Import_RootNamespace>
+    <Import_RootNamespace>MarkdownTextBlockTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleMarkdownTextBlockTestClass.cs" />

--- a/components/MarkdownTextBlock/tests/MarkdownTextBlock.Tests.projitems
+++ b/components/MarkdownTextBlock/tests/MarkdownTextBlock.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>6F0FA793-7CF0-41F9-B7D9-260039B62C8A</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>MarkdownTextBlockExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>MarkdownTextBlock.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleMarkdownTextBlockTestClass.cs" />

--- a/components/MarqueeText/tests/ExampleMarqueeTextTestClass.cs
+++ b/components/MarqueeText/tests/ExampleMarqueeTextTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI.MarqueeTextRns;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace MarqueeTextExperiment.Tests;
+namespace MarqueeText.Tests;
 
 [TestClass]
 public partial class ExampleMarqueeTextTestClass : VisualUITestBase

--- a/components/MarqueeText/tests/ExampleMarqueeTextTestClass.cs
+++ b/components/MarqueeText/tests/ExampleMarqueeTextTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI.MarqueeTextRns;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace MarqueeText.Tests;
+namespace MarqueeTextTests;
 
 [TestClass]
 public partial class ExampleMarqueeTextTestClass : VisualUITestBase

--- a/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml
+++ b/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml
@@ -1,5 +1,5 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="MarqueeText.Tests.ExampleMarqueeTextTestPage"
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<Page x:Class="MarqueeTextTests.ExampleMarqueeTextTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml
+++ b/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="MarqueeTextExperiment.Tests.ExampleMarqueeTextTestPage"
+<Page x:Class="MarqueeText.Tests.ExampleMarqueeTextTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml.cs
+++ b/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace MarqueeTextExperiment.Tests;
+namespace MarqueeText.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml.cs
+++ b/components/MarqueeText/tests/ExampleMarqueeTextTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace MarqueeText.Tests;
+namespace MarqueeTextTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/MarqueeText/tests/MarqueeText.Tests.projitems
+++ b/components/MarqueeText/tests/MarqueeText.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>C5CF2EF7-F605-4D62-95DB-B8C05C8799E0</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>MarqueeTextExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>MarqueeText.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleMarqueeTextTestClass.cs" />

--- a/components/MarqueeText/tests/MarqueeText.Tests.projitems
+++ b/components/MarqueeText/tests/MarqueeText.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>C5CF2EF7-F605-4D62-95DB-B8C05C8799E0</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>MarqueeText.Tests</Import_RootNamespace>
+    <Import_RootNamespace>MarqueeTextTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleMarqueeTextTestClass.cs" />

--- a/components/Notifications/tests/Notifications.Tests.projitems
+++ b/components/Notifications/tests/Notifications.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>695EB17B-60C6-4D00-9D3F-1BC54B6A9500</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>NotificationsExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Notifications.Tests</Import_RootNamespace>
   </PropertyGroup>
     <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)TestAssertHelper.cs" />

--- a/components/Notifications/tests/Notifications.Tests.projitems
+++ b/components/Notifications/tests/Notifications.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>695EB17B-60C6-4D00-9D3F-1BC54B6A9500</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Notifications.Tests</Import_RootNamespace>
+    <Import_RootNamespace>NotificationsTests</Import_RootNamespace>
   </PropertyGroup>
     <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)TestAssertHelper.cs" />

--- a/components/Notifications/tests/TestAssertHelper.cs
+++ b/components/Notifications/tests/TestAssertHelper.cs
@@ -13,7 +13,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class TestAssertHelper

--- a/components/Notifications/tests/TestAssertHelper.cs
+++ b/components/Notifications/tests/TestAssertHelper.cs
@@ -13,7 +13,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class TestAssertHelper

--- a/components/Notifications/tests/TestMail.cs
+++ b/components/Notifications/tests/TestMail.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class TestMail

--- a/components/Notifications/tests/TestMail.cs
+++ b/components/Notifications/tests/TestMail.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class TestMail

--- a/components/Notifications/tests/TestTileContentBuilder.cs
+++ b/components/Notifications/tests/TestTileContentBuilder.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class TestTileContentBuilder

--- a/components/Notifications/tests/TestTileContentBuilder.cs
+++ b/components/Notifications/tests/TestTileContentBuilder.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class TestTileContentBuilder

--- a/components/Notifications/tests/TestToastArguments.cs
+++ b/components/Notifications/tests/TestToastArguments.cs
@@ -11,7 +11,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class TestToastArguments

--- a/components/Notifications/tests/TestToastArguments.cs
+++ b/components/Notifications/tests/TestToastArguments.cs
@@ -11,7 +11,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class TestToastArguments

--- a/components/Notifications/tests/TestToastContentBuilder.cs
+++ b/components/Notifications/tests/TestToastContentBuilder.cs
@@ -10,7 +10,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class TestToastContentBuilder

--- a/components/Notifications/tests/TestToastContentBuilder.cs
+++ b/components/Notifications/tests/TestToastContentBuilder.cs
@@ -10,7 +10,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class TestToastContentBuilder

--- a/components/Notifications/tests/TestWeather.cs
+++ b/components/Notifications/tests/TestWeather.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class TestWeather

--- a/components/Notifications/tests/TestWeather.cs
+++ b/components/Notifications/tests/TestWeather.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class TestWeather

--- a/components/Notifications/tests/Test_Adaptive_Xml.cs
+++ b/components/Notifications/tests/Test_Adaptive_Xml.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class Test_Adaptive_Xml

--- a/components/Notifications/tests/Test_Adaptive_Xml.cs
+++ b/components/Notifications/tests/Test_Adaptive_Xml.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class Test_Adaptive_Xml

--- a/components/Notifications/tests/Test_Badge_Xml.cs
+++ b/components/Notifications/tests/Test_Badge_Xml.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class Test_Badge_Xml

--- a/components/Notifications/tests/Test_Badge_Xml.cs
+++ b/components/Notifications/tests/Test_Badge_Xml.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class Test_Badge_Xml

--- a/components/Notifications/tests/Test_Tile_Xml.cs
+++ b/components/Notifications/tests/Test_Tile_Xml.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class Test_Tile_Xml

--- a/components/Notifications/tests/Test_Tile_Xml.cs
+++ b/components/Notifications/tests/Test_Tile_Xml.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class Test_Tile_Xml

--- a/components/Notifications/tests/Test_Toast_Xml.cs
+++ b/components/Notifications/tests/Test_Toast_Xml.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class Test_Toast_Xml

--- a/components/Notifications/tests/Test_Toast_Xml.cs
+++ b/components/Notifications/tests/Test_Toast_Xml.cs
@@ -9,7 +9,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class Test_Toast_Xml

--- a/components/Notifications/tests/TextXboxModern.cs
+++ b/components/Notifications/tests/TextXboxModern.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace Notifications.Tests;
+namespace NotificationsTests;
 
 [TestClass]
 public class TextXboxModern

--- a/components/Notifications/tests/TextXboxModern.cs
+++ b/components/Notifications/tests/TextXboxModern.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Notifications;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #nullable disable
-namespace NotificationsExperiment.Tests;
+namespace Notifications.Tests;
 
 [TestClass]
 public class TextXboxModern

--- a/components/OpacityMaskView/tests/OpacityMaskView.Tests.projitems
+++ b/components/OpacityMaskView/tests/OpacityMaskView.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>04511143-C2A3-4893-810D-3C1EA2877430</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>OpacityMaskViewExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>OpacityMaskView.Tests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/OpacityMaskView/tests/OpacityMaskView.Tests.projitems
+++ b/components/OpacityMaskView/tests/OpacityMaskView.Tests.projitems
@@ -6,6 +6,6 @@
     <SharedGUID>04511143-C2A3-4893-810D-3C1EA2877430</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>OpacityMaskView.Tests</Import_RootNamespace>
+    <Import_RootNamespace>OpacityMaskViewTests</Import_RootNamespace>
   </PropertyGroup>
 </Project>

--- a/components/Ribbon/tests/Ribbon.Tests.projitems
+++ b/components/Ribbon/tests/Ribbon.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>C18B1738-4AFB-42D9-AC10-298B8F45B71C</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RibbonExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Ribbon.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)RibbonTestClass.cs" />

--- a/components/Ribbon/tests/Ribbon.Tests.projitems
+++ b/components/Ribbon/tests/Ribbon.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>C18B1738-4AFB-42D9-AC10-298B8F45B71C</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Ribbon.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RibbonTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)RibbonTestClass.cs" />

--- a/components/Ribbon/tests/RibbonTestClass.cs
+++ b/components/Ribbon/tests/RibbonTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Controls;
 
-namespace RibbonExperiment.Tests;
+namespace Ribbon.Tests;
 
 [TestClass]
 public partial class RibbonTestClass : VisualUITestBase

--- a/components/Ribbon/tests/RibbonTestClass.cs
+++ b/components/Ribbon/tests/RibbonTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.WinUI.Controls;
 
-namespace Ribbon.Tests;
+namespace RibbonTests;
 
 [TestClass]
 public partial class RibbonTestClass : VisualUITestBase

--- a/components/Ribbon/tests/RibbonTestPage.xaml
+++ b/components/Ribbon/tests/RibbonTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="RibbonExperiment.Tests.RibbonTestPage"
+<Page x:Class="Ribbon.Tests.RibbonTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Ribbon/tests/RibbonTestPage.xaml
+++ b/components/Ribbon/tests/RibbonTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="Ribbon.Tests.RibbonTestPage"
+<Page x:Class="RibbonTests.RibbonTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/Ribbon/tests/RibbonTestPage.xaml.cs
+++ b/components/Ribbon/tests/RibbonTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace RibbonExperiment.Tests;
+namespace Ribbon.Tests;
 
 public sealed partial class RibbonTestPage : Page
 {

--- a/components/Ribbon/tests/RibbonTestPage.xaml.cs
+++ b/components/Ribbon/tests/RibbonTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Ribbon.Tests;
+namespace RibbonTests;
 
 public sealed partial class RibbonTestPage : Page
 {

--- a/components/RivePlayer/tests/ExampleRivePlayerTestClass.cs
+++ b/components/RivePlayer/tests/ExampleRivePlayerTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Labs.WinUI.Rive;
 
-namespace RivePlayer.Tests;
+namespace RivePlayerTests;
 
 // Track https://github.com/CommunityToolkit/Labs-Windows/issues/567
 #if !WINDOWS_WINAPPSDK

--- a/components/RivePlayer/tests/ExampleRivePlayerTestClass.cs
+++ b/components/RivePlayer/tests/ExampleRivePlayerTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Labs.WinUI.Rive;
 
-namespace RivePlayerExperiment.Tests;
+namespace RivePlayer.Tests;
 
 // Track https://github.com/CommunityToolkit/Labs-Windows/issues/567
 #if !WINDOWS_WINAPPSDK

--- a/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml
+++ b/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="RivePlayerExperiment.Tests.ExampleRivePlayerTestPage"
+<Page x:Class="RivePlayer.Tests.ExampleRivePlayerTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml
+++ b/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="RivePlayer.Tests.ExampleRivePlayerTestPage"
+<Page x:Class="RivePlayerTests.ExampleRivePlayerTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml.cs
+++ b/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace RivePlayer.Tests;
+namespace RivePlayerTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml.cs
+++ b/components/RivePlayer/tests/ExampleRivePlayerTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace RivePlayerExperiment.Tests;
+namespace RivePlayer.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/RivePlayer/tests/RivePlayer.Tests.projitems
+++ b/components/RivePlayer/tests/RivePlayer.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>CE024C8F-3AB7-409E-B3D6-684B88C6054B</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RivePlayerExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RivePlayer.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleRivePlayerTestClass.cs" />

--- a/components/RivePlayer/tests/RivePlayer.Tests.projitems
+++ b/components/RivePlayer/tests/RivePlayer.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>CE024C8F-3AB7-409E-B3D6-684B88C6054B</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>RivePlayer.Tests</Import_RootNamespace>
+    <Import_RootNamespace>RivePlayerTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleRivePlayerTestClass.cs" />

--- a/components/Shimmer/tests/ExampleShimmerTestClass.cs
+++ b/components/Shimmer/tests/ExampleShimmerTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace Shimmer.Tests;
+namespace ShimmerTests;
 
 [TestClass]
 public partial class ExampleShimmerTestClass : VisualUITestBase

--- a/components/Shimmer/tests/ExampleShimmerTestClass.cs
+++ b/components/Shimmer/tests/ExampleShimmerTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 
-namespace ShimmerExperiment.Tests;
+namespace Shimmer.Tests;
 
 [TestClass]
 public partial class ExampleShimmerTestClass : VisualUITestBase

--- a/components/Shimmer/tests/ExampleShimmerTestPage.xaml
+++ b/components/Shimmer/tests/ExampleShimmerTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="Shimmer.Tests.ExampleShimmerTestPage"
+<Page x:Class="ShimmerTests.ExampleShimmerTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/Shimmer/tests/ExampleShimmerTestPage.xaml
+++ b/components/Shimmer/tests/ExampleShimmerTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="ShimmerExperiment.Tests.ExampleShimmerTestPage"
+<Page x:Class="Shimmer.Tests.ExampleShimmerTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/Shimmer/tests/ExampleShimmerTestPage.xaml.cs
+++ b/components/Shimmer/tests/ExampleShimmerTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Shimmer.Tests;
+namespace ShimmerTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Shimmer/tests/ExampleShimmerTestPage.xaml.cs
+++ b/components/Shimmer/tests/ExampleShimmerTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace ShimmerExperiment.Tests;
+namespace Shimmer.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/Shimmer/tests/Shimmer.Tests.projitems
+++ b/components/Shimmer/tests/Shimmer.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>02EDA7A2-0AD0-449E-AD75-E9B363620679</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Shimmer.Tests</Import_RootNamespace>
+    <Import_RootNamespace>ShimmerTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleShimmerTestClass.cs" />

--- a/components/Shimmer/tests/Shimmer.Tests.projitems
+++ b/components/Shimmer/tests/Shimmer.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>02EDA7A2-0AD0-449E-AD75-E9B363620679</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>ShimmerExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>Shimmer.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleShimmerTestClass.cs" />

--- a/components/TitleBar/tests/ExampleTitleBarTestClass.cs
+++ b/components/TitleBar/tests/ExampleTitleBarTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TitleBar.Tests;
+namespace TitleBarTests;
 
 [TestClass]
 public partial class ExampleTitleBarTestClass : VisualUITestBase

--- a/components/TitleBar/tests/ExampleTitleBarTestClass.cs
+++ b/components/TitleBar/tests/ExampleTitleBarTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
 
-namespace TitleBarExperiment.Tests;
+namespace TitleBar.Tests;
 
 [TestClass]
 public partial class ExampleTitleBarTestClass : VisualUITestBase

--- a/components/TitleBar/tests/ExampleTitleBarTestPage.xaml
+++ b/components/TitleBar/tests/ExampleTitleBarTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="TitleBar.Tests.ExampleTitleBarTestPage"
+<Page x:Class="TitleBarTests.ExampleTitleBarTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/TitleBar/tests/ExampleTitleBarTestPage.xaml
+++ b/components/TitleBar/tests/ExampleTitleBarTestPage.xaml
@@ -1,5 +1,5 @@
 ﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="TitleBarExperiment.Tests.ExampleTitleBarTestPage"
+<Page x:Class="TitleBar.Tests.ExampleTitleBarTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"

--- a/components/TitleBar/tests/ExampleTitleBarTestPage.xaml.cs
+++ b/components/TitleBar/tests/ExampleTitleBarTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace TitleBar.Tests;
+namespace TitleBarTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/TitleBar/tests/ExampleTitleBarTestPage.xaml.cs
+++ b/components/TitleBar/tests/ExampleTitleBarTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace TitleBarExperiment.Tests;
+namespace TitleBar.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/TitleBar/tests/TitleBar.Tests.projitems
+++ b/components/TitleBar/tests/TitleBar.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>3BA0AB2F-24A8-4E53-BEFE-2796E3E82421</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TitleBar.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TitleBarTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTitleBarTestClass.cs" />

--- a/components/TitleBar/tests/TitleBar.Tests.projitems
+++ b/components/TitleBar/tests/TitleBar.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>3BA0AB2F-24A8-4E53-BEFE-2796E3E82421</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TitleBarExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TitleBar.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTitleBarTestClass.cs" />

--- a/components/TokenView/tests/ExampleTokenViewTestClass.cs
+++ b/components/TokenView/tests/ExampleTokenViewTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace TokenView.Tests;
+namespace TokenViewTests;
 
 [TestClass]
 public partial class ExampleTokenViewTestClass : VisualUITestBase

--- a/components/TokenView/tests/ExampleTokenViewTestClass.cs
+++ b/components/TokenView/tests/ExampleTokenViewTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace TokenViewExperiment.Tests;
+namespace TokenView.Tests;
 
 [TestClass]
 public partial class ExampleTokenViewTestClass : VisualUITestBase

--- a/components/TokenView/tests/ExampleTokenViewTestPage.xaml
+++ b/components/TokenView/tests/ExampleTokenViewTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="TokenViewExperiment.Tests.ExampleTokenViewTestPage"
+<Page x:Class="TokenView.Tests.ExampleTokenViewTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/TokenView/tests/ExampleTokenViewTestPage.xaml
+++ b/components/TokenView/tests/ExampleTokenViewTestPage.xaml
@@ -1,5 +1,5 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
-<Page x:Class="TokenView.Tests.ExampleTokenViewTestPage"
+<Page x:Class="TokenViewTests.ExampleTokenViewTestPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/components/TokenView/tests/ExampleTokenViewTestPage.xaml.cs
+++ b/components/TokenView/tests/ExampleTokenViewTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace TokenViewExperiment.Tests;
+namespace TokenView.Tests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/TokenView/tests/ExampleTokenViewTestPage.xaml.cs
+++ b/components/TokenView/tests/ExampleTokenViewTestPage.xaml.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace TokenView.Tests;
+namespace TokenViewTests;
 
 /// <summary>
 /// An empty page that can be used on its own or navigated to within a Frame.

--- a/components/TokenView/tests/TokenView.Tests.projitems
+++ b/components/TokenView/tests/TokenView.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>7E8E1DC7-8A48-4270-A926-1A8C4D17DBD0</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TokenViewExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TokenView.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTokenViewTestClass.cs" />

--- a/components/TokenView/tests/TokenView.Tests.projitems
+++ b/components/TokenView/tests/TokenView.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>7E8E1DC7-8A48-4270-A926-1A8C4D17DBD0</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TokenView.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TokenViewTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTokenViewTestClass.cs" />

--- a/components/TransitionHelper/tests/ExampleTransitionHelperTestClass.cs
+++ b/components/TransitionHelper/tests/ExampleTransitionHelperTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace TransitionHelperExperiment.Tests;
+namespace TransitionHelper.Tests;
 
 [TestClass]
 public partial class ExampleTransitionHelperTestClass : VisualUITestBase

--- a/components/TransitionHelper/tests/ExampleTransitionHelperTestClass.cs
+++ b/components/TransitionHelper/tests/ExampleTransitionHelperTestClass.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Labs.WinUI;
 using CommunityToolkit.Tests;
 using CommunityToolkit.Tooling.TestGen;
 
-namespace TransitionHelper.Tests;
+namespace TransitionHelperTests;
 
 [TestClass]
 public partial class ExampleTransitionHelperTestClass : VisualUITestBase

--- a/components/TransitionHelper/tests/TransitionHelper.Tests.projitems
+++ b/components/TransitionHelper/tests/TransitionHelper.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>F2D39FE2-BDFC-4E8C-9948-272F5272F936</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TransitionHelperExperiment.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TransitionHelper.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTransitionHelperTestClass.cs" />

--- a/components/TransitionHelper/tests/TransitionHelper.Tests.projitems
+++ b/components/TransitionHelper/tests/TransitionHelper.Tests.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>F2D39FE2-BDFC-4E8C-9948-272F5272F936</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>TransitionHelper.Tests</Import_RootNamespace>
+    <Import_RootNamespace>TransitionHelperTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExampleTransitionHelperTestClass.cs" />


### PR DESCRIPTION
Full list of changes can be found in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/272

Requires prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/273