### PR TITLE
Removed the MainLatest feed from nuget.config, update to 8.2

### DIFF
--- a/components/CanvasView/src/Dependencies.props
+++ b/components/CanvasView/src/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250129-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/CanvasView/src/Dependencies.props
+++ b/components/CanvasView/src/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250402"/>
   </ItemGroup>
 </Project>

--- a/components/DataTable/samples/Dependencies.props
+++ b/components/DataTable/samples/Dependencies.props
@@ -11,14 +11,14 @@
 <Project>
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.2.250402"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250402"/>
     </ItemGroup>
 
     <!-- WinUI 2 / UWP -->

--- a/components/DataTable/samples/Dependencies.props
+++ b/components/DataTable/samples/Dependencies.props
@@ -11,14 +11,14 @@
 <Project>
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.241223-build.1367"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.2.250129-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241223-build.1367"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250129-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 2 / UWP -->

--- a/components/DataTable/src/Dependencies.props
+++ b/components/DataTable/src/Dependencies.props
@@ -14,15 +14,15 @@
   
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.2.241223-build.1367"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.241223-build.1367"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.2.250129-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.241223-build.1367"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.241223-build.1367"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250129-preview2"/>
     </ItemGroup>
 </Project>

--- a/components/DataTable/src/Dependencies.props
+++ b/components/DataTable/src/Dependencies.props
@@ -14,15 +14,15 @@
   
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.2.250129-preview2"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250129-preview2"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.2.250402"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250129-preview2"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250402"/>
     </ItemGroup>
 </Project>

--- a/components/RivePlayer/samples/Dependencies.props
+++ b/components/RivePlayer/samples/Dependencies.props
@@ -12,24 +12,24 @@
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
         <!-- <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
         <!-- <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
         <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.100-dev.15.g12261e2626"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
     </ItemGroup>
 </Project>

--- a/components/RivePlayer/samples/Dependencies.props
+++ b/components/RivePlayer/samples/Dependencies.props
@@ -12,24 +12,24 @@
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
         <!-- <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
         <!-- <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
         <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.100-dev.15.g12261e2626"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241223-build.1367"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
     </ItemGroup>
 </Project>

--- a/components/Shimmer/src/Dependencies.props
+++ b/components/Shimmer/src/Dependencies.props
@@ -12,24 +12,24 @@
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
     <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.3"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.241223-build.1367" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2" />
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
     <!--  <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.241223-build.1367" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
     <!-- <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.241223-build.1367" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
     <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.241223-build.1367" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2" />
   </ItemGroup>
 </Project>

--- a/components/Shimmer/src/Dependencies.props
+++ b/components/Shimmer/src/Dependencies.props
@@ -12,24 +12,24 @@
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
     <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.3"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402" />
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
     <!--  <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
     <!-- <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
     <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402" />
   </ItemGroup>
 </Project>

--- a/components/TokenView/src/Dependencies.props
+++ b/components/TokenView/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402"/>
   </ItemGroup>
 </Project>

--- a/components/TokenView/src/Dependencies.props
+++ b/components/TokenView/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250129-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/samples/Dependencies.props
+++ b/components/TransitionHelper/samples/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/samples/Dependencies.props
+++ b/components/TransitionHelper/samples/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/src/Dependencies.props
+++ b/components/TransitionHelper/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/src/Dependencies.props
+++ b/components/TransitionHelper/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.241223-build.1367"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.241223-build.1367"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250129-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250129-preview2"/>
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
-    <add key="LabsFeed" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
This PR fixes an issue where opening or building the solution results in an error "Error occurred while getting package vulnerability data"

Closes #662
Closes #641

Prerequisite PR https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/279