### PR TITLE
Fix CI error for detecting changed components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,8 +266,7 @@ jobs:
       # Get changed components
       - name: Get changed components
         run: |
-          $components = ./tooling/Get-Changed-Components.ps1
-          echo "CHANGED_COMPONENTS_LIST=$components" >> $env:GITHUB_ENV
+          echo "CHANGED_COMPONENTS_LIST=$(./tooling/Get-Changed-Components.ps1)" >> $env:GITHUB_ENV
 
       # Build and pack component nupkg
       - name: Build and pack component packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,7 @@ jobs:
 
       - name: Get changed components
         run: |
-          $components = ./tooling/Get-Changed-Components.ps1
-          echo "CHANGED_COMPONENTS_LIST=$components" >> $env:GITHUB_ENV
+          echo "CHANGED_COMPONENTS_LIST=$(./tooling/Get-Changed-Components.ps1)" >> $env:GITHUB_ENV
 
       # Generate full solution with all projects (sample gallery heads, components, tests)
       - name: Generate solution with ${{ matrix.multitarget }} gallery, components and tests


### PR DESCRIPTION
This PR fixes an issue originally introduced in https://github.com/CommunityToolkit/Labs-Windows/pull/647 that is now causing our CI to [fail on `main`](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/14838707175).

The fix was tested using a [manual CI run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/14840484283) of this `fix/ci` branch.