### PR TITLE
Add `DisableHtml` property to MarkdownTextBlock

### DIFF
--- a/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
+++ b/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="MarkdownTextBlockExperiment.Samples.MarkdownTextBlockCustomSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -27,15 +27,15 @@
             </Grid.ColumnDefinitions>
             <controls:MarkdownTextBlock x:Name="MarkdownTextBlock1"
                                         Grid.Column="0"
-                                        UseEmphasisExtras="{x:Bind UseEmphasisExtras, Mode=OneWay}"
-                                        UsePipeTables="{x:Bind UsePipeTables, Mode=OneWay}"
-                                        UseListExtras="{x:Bind UseListExtras, Mode=OneWay}"
-                                        UseTaskLists="{x:Bind UseTaskLists, Mode=OneWay}"
-                                        UseAutoLinks="{x:Bind UseAutoLinks, Mode=OneWay}"
-                                        DisableHtml="{x:Bind DisableHtml, Mode=OneWay}"
-                                        UseSoftlineBreakAsHardlineBreak="{x:Bind UseSoftlineBreakAsHardlineBreak, Mode=OneWay}"
                                         Config="{x:Bind LiveMarkdownConfig, Mode=OneTime}"
-                                        Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}" />
+                                        DisableHtml="{x:Bind DisableHtml, Mode=OneWay}"
+                                        Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}"
+                                        UseAutoLinks="{x:Bind UseAutoLinks, Mode=OneWay}"
+                                        UseEmphasisExtras="{x:Bind UseEmphasisExtras, Mode=OneWay}"
+                                        UseListExtras="{x:Bind UseListExtras, Mode=OneWay}"
+                                        UsePipeTables="{x:Bind UsePipeTables, Mode=OneWay}"
+                                        UseSoftlineBreakAsHardlineBreak="{x:Bind UseSoftlineBreakAsHardlineBreak, Mode=OneWay}"
+                                        UseTaskLists="{x:Bind UseTaskLists, Mode=OneWay}" />
             <TextBox x:Name="MarkdownTextBox"
                      Grid.Column="1"
                      AcceptsReturn="True" />

--- a/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
+++ b/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml
@@ -27,6 +27,13 @@
             </Grid.ColumnDefinitions>
             <controls:MarkdownTextBlock x:Name="MarkdownTextBlock1"
                                         Grid.Column="0"
+                                        UseEmphasisExtras="{x:Bind UseEmphasisExtras, Mode=OneWay}"
+                                        UsePipeTables="{x:Bind UsePipeTables, Mode=OneWay}"
+                                        UseListExtras="{x:Bind UseListExtras, Mode=OneWay}"
+                                        UseTaskLists="{x:Bind UseTaskLists, Mode=OneWay}"
+                                        UseAutoLinks="{x:Bind UseAutoLinks, Mode=OneWay}"
+                                        DisableHtml="{x:Bind DisableHtml, Mode=OneWay}"
+                                        UseSoftlineBreakAsHardlineBreak="{x:Bind UseSoftlineBreakAsHardlineBreak, Mode=OneWay}"
                                         Config="{x:Bind LiveMarkdownConfig, Mode=OneTime}"
                                         Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}" />
             <TextBox x:Name="MarkdownTextBox"

--- a/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml.cs
+++ b/components/MarkdownTextBlock/samples/MarkdownTextBlockCustomSample.xaml.cs
@@ -9,6 +9,13 @@ namespace MarkdownTextBlockExperiment.Samples;
 /// <summary>
 /// An example sample page of a custom control inheriting from Panel.
 /// </summary>
+[ToolkitSampleBoolOption("UseEmphasisExtras", false, Title = "UseEmphasisExtras")]
+[ToolkitSampleBoolOption("UsePipeTables", false, Title = "UsePipeTables")]
+[ToolkitSampleBoolOption("UseListExtras", false, Title = "UseListExtras")]
+[ToolkitSampleBoolOption("UseTaskLists", false, Title = "UseTaskLists")]
+[ToolkitSampleBoolOption("UseAutoLinks", false, Title = "UseAutoLinks")]
+[ToolkitSampleBoolOption("DisableHtml", false, Title = "DisableHtml")]
+[ToolkitSampleBoolOption("UseSoftlineBreakAsHardlineBreak", false, Title = "UseSoftlineBreakAsHardlineBreak")]
 [ToolkitSample(id: nameof(MarkdownTextBlockCustomSample), "Custom control", description: $"A sample for showing how to create and use a {nameof(CommunityToolkit.Labs.WinUI.MarkdownTextBlock)} custom control.")]
 public sealed partial class MarkdownTextBlockCustomSample : Page
 {

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
@@ -73,6 +73,15 @@ public partial class MarkdownTextBlock
         new PropertyMetadata(false));
 
     /// <summary>
+    /// Identifies the <see cref="DisableHtmlProperty"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty DisableHtmlProperty = DependencyProperty.Register(
+        nameof(DisableHtmlProperty),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    /// <summary>
     /// Identifies the <see cref="UseSoftlineBreakAsHardlineBreak"/> dependency property.
     /// </summary>
     private static readonly DependencyProperty UseSoftlineBreakAsHardlineBreakProperty = DependencyProperty.Register(
@@ -148,6 +157,15 @@ public partial class MarkdownTextBlock
     {
         get => (bool)GetValue(UseAutoLinksProperty);
         set => SetValue(UseAutoLinksProperty, value);
+    }
+
+    /// <summary>
+    /// If true, Disables HTML parsing.
+    /// </summary>
+    public bool DisableHtml
+    {
+        get => (bool)GetValue(DisableHtmlProperty);
+        set => SetValue(DisableHtmlProperty, value);
     }
 
     /// <summary>

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
@@ -60,6 +60,7 @@ public partial class MarkdownTextBlock : Control
         if (UseTaskLists) pipelineBuilder = pipelineBuilder.UseTaskLists();
         if (UseAutoLinks) pipelineBuilder = pipelineBuilder.UseAutoLinks();
         if (UseSoftlineBreakAsHardlineBreak) pipelineBuilder = pipelineBuilder.UseSoftlineBreakAsHardlineBreak();
+        if (DisableHtml) pipelineBuilder = pipelineBuilder.DisableHtml();
 
         _pipeline = pipelineBuilder.Build();
 
@@ -110,14 +111,14 @@ public partial class MarkdownTextBlock : Control
                 _renderer.ObjectRenderers.Add(new ParagraphRenderer());
                 _renderer.ObjectRenderers.Add(new QuoteBlockRenderer());
                 _renderer.ObjectRenderers.Add(new ThematicBreakRenderer());
-                _renderer.ObjectRenderers.Add(new HtmlBlockRenderer());
+                if (!DisableHtml) _renderer.ObjectRenderers.Add(new HtmlBlockRenderer());
 
                 // Default inline renderers
                 if (UseAutoLinks) _renderer.ObjectRenderers.Add(new AutoLinkInlineRenderer());
                 _renderer.ObjectRenderers.Add(new CodeInlineRenderer());
                 _renderer.ObjectRenderers.Add(new DelimiterInlineRenderer());
                 _renderer.ObjectRenderers.Add(new EmphasisInlineRenderer());
-                _renderer.ObjectRenderers.Add(new HtmlEntityInlineRenderer());
+                if (!DisableHtml) _renderer.ObjectRenderers.Add(new HtmlEntityInlineRenderer());
                 _renderer.ObjectRenderers.Add(new LineBreakInlineRenderer());
                 _renderer.ObjectRenderers.Add(new LinkInlineRenderer());
                 _renderer.ObjectRenderers.Add(new LiteralInlineRenderer());
@@ -126,7 +127,7 @@ public partial class MarkdownTextBlock : Control
                 // Extension renderers
                 if (UsePipeTables) _renderer.ObjectRenderers.Add(new TableRenderer());
                 if (UseTaskLists) _renderer.ObjectRenderers.Add(new TaskListRenderer());
-                _renderer.ObjectRenderers.Add(new HtmlInlineRenderer());
+                if (!DisableHtml) _renderer.ObjectRenderers.Add(new HtmlInlineRenderer());
             }
             _pipeline.Setup(_renderer);
             ApplyText(false);


### PR DESCRIPTION
Calls DisableHtml method on Markdig pipeline, as well as not adding any Html based renderer, HtmlBlockRenderer, HtmlEntityInlineRenderer, and HtmlInlineRenderer. When enabled, results in any html tags being ignored and plain-text parts remaining, unformatted.

Committing Patch on behalf of Ameya Kulkarni