### PR TITLE
Add LabsFeed source inline instead of using nuget.config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,8 @@ jobs:
       - name: Push packages (main)
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          dotnet nuget update source LabsFeed `
+          dotnet nuget add source https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json `
+            --name LabsFeed `
             --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
           dotnet nuget push "**/*.nupkg" --api-key dummy --source LabsFeed --skip-duplicate
 


### PR DESCRIPTION
This PR fixes errors we're seeing in CI [here](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/14872542740/job/41765083660#step:13:1) in the "Push packages (main)" step:
```
Run dotnet nuget update source LabsFeed `
error: Object reference not set to an instance of an object.
error: The specified source 'LabsFeed' is invalid. Provide a valid source.
Error: Process completed with exit code 1.
```

This regression was introduced in https://github.com/CommunityToolkit/Labs-Windows/pull/663