### PR TITLE
Add property to disable links

### DIFF
--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
@@ -82,6 +82,15 @@ public partial class MarkdownTextBlock
         new PropertyMetadata(false));
 
     /// <summary>
+    /// Identifies the <see cref="DisableLinksProperty"/> dependency property.
+    /// </summary>
+    private static readonly DependencyProperty DisableLinksProperty = DependencyProperty.Register(
+        nameof(DisableLinksProperty),
+        typeof(bool),
+        typeof(MarkdownTextBlock),
+        new PropertyMetadata(false));
+
+    /// <summary>
     /// Identifies the <see cref="UseSoftlineBreakAsHardlineBreak"/> dependency property.
     /// </summary>
     private static readonly DependencyProperty UseSoftlineBreakAsHardlineBreakProperty = DependencyProperty.Register(
@@ -166,6 +175,15 @@ public partial class MarkdownTextBlock
     {
         get => (bool)GetValue(DisableHtmlProperty);
         set => SetValue(DisableHtmlProperty, value);
+    }
+
+    /// <summary>
+    /// If true, Disables link parsing.
+    /// </summary>
+    public bool DisableLinks
+    {
+        get => (bool)GetValue(DisableLinksProperty);
+        set => SetValue(DisableLinksProperty, value);
     }
 
     /// <summary>

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.xaml.cs
@@ -120,9 +120,9 @@ public partial class MarkdownTextBlock : Control
                 _renderer.ObjectRenderers.Add(new EmphasisInlineRenderer());
                 if (!DisableHtml) _renderer.ObjectRenderers.Add(new HtmlEntityInlineRenderer());
                 _renderer.ObjectRenderers.Add(new LineBreakInlineRenderer());
-                _renderer.ObjectRenderers.Add(new LinkInlineRenderer());
+                if (!DisableLinks) _renderer.ObjectRenderers.Add(new LinkInlineRenderer());
                 _renderer.ObjectRenderers.Add(new LiteralInlineRenderer());
-                _renderer.ObjectRenderers.Add(new ContainerInlineRenderer());
+                if (!DisableLinks) _renderer.ObjectRenderers.Add(new ContainerInlineRenderer());
 
                 // Extension renderers
                 if (UsePipeTables) _renderer.ObjectRenderers.Add(new TableRenderer());

--- a/components/MarkdownTextBlock/src/TextElements/MyList.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyList.cs
@@ -82,6 +82,7 @@ internal class MyList : IAddChild
         textBlock.SetValue(Grid.ColumnProperty, 0);
         textBlock.VerticalAlignment = VerticalAlignment.Top;
         textBlock.TextAlignment = TextAlignment.Right;
+        AutomationProperties.SetAccessibilityView(textBlock, AccessibilityView.Raw);
         grid.Children.Add(textBlock);
         var flowDoc = new MyFlowDocument();
         flowDoc.AddChild(child);

--- a/components/MarkdownTextBlock/src/TextElements/MyList.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyList.cs
@@ -82,6 +82,7 @@ internal class MyList : IAddChild
         textBlock.SetValue(Grid.ColumnProperty, 0);
         textBlock.VerticalAlignment = VerticalAlignment.Top;
         textBlock.TextAlignment = TextAlignment.Right;
+        // Mark this Raw so narrator users will not set focus on it
         AutomationProperties.SetAccessibilityView(textBlock, AccessibilityView.Raw);
         grid.Children.Add(textBlock);
         var flowDoc = new MyFlowDocument();


### PR DESCRIPTION
Enable a way to make markdown rendering more secure. Addition of DisableLinks property will let consumers of control customize  a way to disable all links and inline image rendering.

This change also fixes an issue with Windows narrator usage and marks the bullet graphic as decorative