### PR TITLE
Fix param input formatting for changed components list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           $changedComponents = $(./tooling/Get-Changed-Components.ps1)
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets ${{ matrix.multitarget }} -WinUIMajorVersion ${{ matrix.winui }})
-          echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "'$_'" }) -join ',')" >> $env:GITHUB_ENV
+          echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV
 
       # Generate full solution with all projects (sample gallery heads, components, tests)
@@ -270,7 +270,7 @@ jobs:
         run: |
           $changedComponents = $(./tooling/Get-Changed-Components.ps1)
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets "all" -WinUIMajorVersion ${{ matrix.winui }})
-          echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "'$_'" }) -join ',')" >> $env:GITHUB_ENV
+          echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV
 
       # Build and pack component nupkg


### PR DESCRIPTION
Fixes a CI issue discovered in the inline Build.yml in [this actions run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/15545367812), originally introduced in https://github.com/CommunityToolkit/Labs-Windows/pull/681:
![image](https://github.com/user-attachments/assets/6b508e71-d13b-44a9-b3ba-257aedff6d8d)

