### PR TITLE
Fix SHA range for incremental CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
             # Get changed components
       - name: Get changed components
         run: |
-          $changedComponents = $(./tooling/Get-Changed-Components.ps1 -FromSha ${{ github.event.before }} -ToSha ${{ github.event.after }})
+          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ github.event.before }} ${{ github.event.after }})
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets ${{ matrix.multitarget }} -WinUIMajorVersion ${{ matrix.winui }})
           echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV
@@ -268,7 +268,7 @@ jobs:
             # Get changed components
       - name: Get changed components
         run: |
-          $changedComponents = $(./tooling/Get-Changed-Components.ps1 -FromSha ${{ github.event.before }} -ToSha ${{ github.event.after }})
+          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ github.event.before }} ${{ github.event.after }})
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets "all" -WinUIMajorVersion ${{ matrix.winui }})
           echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV


### PR DESCRIPTION
### Overview

This PR fixes an issue with incremental CI builds where `origin/main` was used as the base `FromSha` even when the workflow is triggered via push/merge to the `main` branch. 

The solution here was to use the `github.event.before` and `github.event.after` variables supplied by Actions, which is available when the workflow is triggered via both `push` or `pull_request`. 

This means that component packages will only be pushed to NuGet for *pushed commit ranges*, not for all changes made since branching from a base (e.g. our original `origin/main`).

This should support scenarios for both incremental batch PR pushes and merging them (rebase or otherwise) into `main`, since the variable is given for both `push` and `pull_request` events.

### Change validation

This approach has been tested from the `push` action by temporarily changing the push branches to include 'ci/dev/**' (see 4f62ddbd4528e6332884bd07e49873b822e7ea82) and making subsequent pushes.
- [This run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/15910261028) validated that a small change to build.yml (here, a syntax error fix) correctly builds and packages all components.
- From [this commit](https://github.com/CommunityToolkit/Labs-Windows/commit/df913fa6cfb00c764d3c52ffa5c3593cffbe2465), [this Actions run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/15910325567) validated that making a small change to a component (here, adding newlines to a src csproj) correctly builds and packages only that one component. 

### A note on new branches

It has also been verified to work for new branches, where a Null SHA (all 0's) is given for the `FromSha`. Given this value as the start of a commit range, git compares all prior history-- meaning `all` components will be built for a new branch.

Knowing this, we can customize this functionality if/as needed. 

### ~~Breaking changes~~

Since the `github.event.before` and `github.event.after` variables supplied by Actions are only available during `push` and `pull_request` events, we'll now get an empty string for manually dispatched workflow runs. This can be seen in [this run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/15890083811) and will cause CI consistent failures.

A few options to remedy this:
- Use positional script parameters instead of named parameters, try to use the fallback comparison of `head` against `origin/main`. Doesn't support incremental builds.
- Revert a52c25dade5eeb67700da0f51c99e198273a96d1 and enable CI runs on the `push` event for `ci/dev/**` branches specifically for testing changes to the CI workflow. Instead of selecting a branch from the GitHub Actions web interface, you'd make a push. These branches can be protected in GitHub settings. 

The latter needs wider consideration, but the former is trivial and ~~will be pushed once tested locally~~ has been pushed to e086cc5342731068de6baa60d6aa5cf9f45b041a.
