### PR TITLE
Add weekly merge workflow and update CI triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,19 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [ main, 'rel/weekly' ]
   pull_request:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   merge_group:
+
+  # Allow this workflow to be triggered by scheduled release workflows
+  workflow_run:
+    workflows: [ WeeklyMerge ]
+    types:
+      - completed
 
 env:
   DOTNET_VERSION: ${{ '9.0.x' }}

--- a/.github/workflows/weekly-merge.yml
+++ b/.github/workflows/weekly-merge.yml
@@ -1,0 +1,36 @@
+name: WeeklyMerge
+
+on:
+  schedule:
+    # Runs every Wednesday at 08:00 UTC (midnight PST / 1:00 AM PDT)
+    - cron: '0 8 * * 3'
+
+  # Allows manual triggering for convenience
+  workflow_dispatch:
+
+jobs:
+  weekly-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Use a token with write permissions to push to the branch
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # Fetch all history for merging
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Merge main into rel/weekly
+        run: |
+          git fetch origin
+          git checkout rel/weekly
+          git reset --hard origin/rel/weekly
+          git merge --no-ff origin/main -m "Weekly merge of main into rel/weekly"
+          git push origin rel/weekly


### PR DESCRIPTION
This PR adds a `weekly-merge.yml` workflow file that merges `main` into `rel/weekly`. 

When this merge happens, our usual `build.yml` will be triggered and should diff with the merge from the week prior (the last push).

If no incremental changes are found by our `build.yml`, the build will exit early as usual.