### PR TITLE
Fixed checkout depth error in scheduled weekly CI workflow

### DIFF
--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
After testing #696 in https://github.com/CommunityToolkit/Labs-Windows/actions/runs/16616965286/job/47011751224, we found the following error:
```
could not compute title or body defaults: failed to run git: fatal: ambiguous argument 'origin/rel/weekly...main': unknown revision or path not in the working tree.
```