### PR TITLE
Fix build.yml workflow triggers for pull requests to include 'rel/weekly' branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main, 'rel/weekly' ]
-  pull_request:
     branches: [ main ]
+  pull_request:
+    branches: [ main, 'rel/weekly' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
After testing https://github.com/CommunityToolkit/Labs-Windows/pull/697 in https://github.com/CommunityToolkit/Labs-Windows/pull/698, we found that the `build.yml` workflow wasn't being triggered when the scheduled merge PR was closed. 

This PR fixes that by including the branch `rel/weekly` in the `pull_request` event triggers for the build workflow.