### PR TITLE
Fix --fill-verbose parameter conflict in scheduled releases workflow

### DIFF
--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       # Declare to satisfy linter, will be set dynamically during workflow execution
       PR_NUMBER: ""
+      HAS_NEW_COMMITS: ""
 
     steps:
       - name: Checkout repository
@@ -27,7 +28,15 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
+      - name: Check for new commits
+        shell: pwsh
+        run: |
+          # Check if there are commits between rel/weekly and main
+          $commitCount = git rev-list --count rel/weekly..main
+          echo "HAS_NEW_COMMITS=$($commitCount -gt 0)" >> $env:GITHUB_ENV
+
       - name: Create weekly release PR
+        if: ${{ env.HAS_NEW_COMMITS == 'true' }}
         shell: pwsh
         run: |
           # Create PR from main to rel/weekly, capture created URL
@@ -45,6 +54,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for the PR
+        if: ${{ env.HAS_NEW_COMMITS == 'true' }}
         shell: pwsh
         run: |
           gh pr merge ${{ env.PR_NUMBER }} --auto --rebase

--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -35,7 +35,6 @@ jobs:
             --base rel/weekly `
             --head main `
             --title "Scheduled weekly release $(Get-Date -Format 'yyyy-MM-dd')" `
-            --body "Automated weekly release PR created by scheduled workflow." `
             --fill-verbose `
             --reviewer michael-hawker)
           


### PR DESCRIPTION
### Problem
The `--fill-verbose` flag in the scheduled releases workflow wasn't working as expected. Instead of populating the PR description with detailed commit information from changes between `rel/weekly` and `main`, it was only showing the generic message we provided via the `--body` parameter.

### Root Cause
After investigating the GitHub CLI documentation (`gh pr create --help`), we discovered that when both `--body` and `--fill-verbose` flags are provided together, the `--body` parameter takes precedence and overwrites any autofilled content from `--fill-verbose`.

### Solution
Removed the conflicting `--body` parameter from the `gh pr create` command in the scheduled releases workflow.

### Additional Issue Discovered
When testing the fix with `gh pr create --fill-verbose --dry-run`, we discovered that the command fails with "could not find any commits between origin/rel/weekly and main" when the branches are synchronized (no new commits). This would cause the scheduled workflow to fail when there's nothing to release.

### Additional Solution
Added early exit logic following the same pattern used in `build.yml` - the workflow now checks if there are new commits between `rel/weekly` and `main` before attempting to create a PR, preventing failures when branches are synchronized.

### End Result
- The scheduled weekly release PRs will now automatically include detailed commit information in their descriptions, showing exactly what changes are being released each week instead of just a generic automated message.
- The workflow gracefully handles cases where there are no new commits to release, skipping PR creation entirely.
