### PR TITLE
Use remote branch reference in scheduled-releases workflow

### DIFF
--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -32,7 +32,7 @@ jobs:
         shell: pwsh
         run: |
           # Check if there are commits between rel/weekly and main
-          $commitCount = git rev-list --count rel/weekly..main
+          $commitCount = git rev-list --count origin/rel/weekly..main
           echo "HAS_NEW_COMMITS=$($commitCount -gt 0)" >> $env:GITHUB_ENV
 
       - name: Create weekly release PR


### PR DESCRIPTION
The `scheduled-releases` workflow was failing with "unknown revision" error when comparing `rel/weekly..main`. 

The `actions/checkout@v4` action with `fetch-depth: 0` fetches all remote branch history but doesn't create local tracking branches. Changed the git command to use `origin/rel/weekly` instead of `rel/weekly` to reference the remote branch that's actually available after checkout.

Fixes: https://github.com/CommunityToolkit/Labs-Windows/actions/runs/16633867803/job/47069979589
Related: https://github.com/actions/checkout/issues/1017
