### PR TITLE
Fix workflow triggers and branch desync for scheduled releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [ main, 'rel/weekly' ]
   pull_request:
     branches: [ main, 'rel/weekly' ]
 

--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -57,6 +57,7 @@ jobs:
         if: ${{ env.HAS_NEW_COMMITS == 'true' }}
         shell: pwsh
         run: |
-          gh pr merge ${{ env.PR_NUMBER }} --auto --rebase
+          # Should result in fast-forward unless branch histories diverge 
+          gh pr merge ${{ env.PR_NUMBER }} --auto --merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes:
- The `This branch is 4 commits ahead of, 7 commits behind main.` observed on the `rel/weekly` branch after #702 closed.
- build.yml not running on `rel/weekly` when PRs are closed (via the push  dispatch trigger)