### PR TITLE
Fix secret inheritance in scheduled workflows

### DIFF
--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -39,3 +39,4 @@ jobs:
   trigger-build:
     needs: merge-weekly
     uses: CommunityToolkit/Labs-Windows/.github/workflows/build.yml@rel/weekly
+    secrets: inherit


### PR DESCRIPTION
This PR fixes the issue observed in https://github.com/CommunityToolkit/Labs-Windows/actions/runs/16771182198 where the package job was failing due to a missing `secrets.DEVOPS_PACKAGE_PUSH_TOKEN` in the push step.