### PR TITLE
Adding overridable MinWidth for TitleBarContent

### DIFF
--- a/components/TitleBar/samples/SamplePages/ShellPage.xaml
+++ b/components/TitleBar/samples/SamplePages/ShellPage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="TitleBarExperiment.Samples.ShellPage"
+﻿<Page x:Class="TitleBarExperiment.Samples.ShellPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"
@@ -23,6 +23,10 @@
                            IsPaneButtonVisible="True"
                            PaneButtonClick="appTitleBar_PaneButtonClick"
                            Subtitle="Preview">
+            <controls:TitleBar.Resources>
+                <!--  Example of overriding the MinWidth of the SearchBox so it's extra wide  -->
+                <x:Double x:Key="TitleBarContentMinWidth">600</x:Double>
+            </controls:TitleBar.Resources>
             <controls:TitleBar.Icon>
                 <BitmapIcon ShowAsMonochrome="False"
                             UriSource="ms-appx:///Assets/AppTitleBarIcon.png" />

--- a/components/TitleBar/src/TitleBar.xaml
+++ b/components/TitleBar/src/TitleBar.xaml
@@ -7,7 +7,7 @@
 
     <x:Double x:Key="TitleBarCompactHeight">32</x:Double>
     <x:Double x:Key="TitleBarTallHeight">48</x:Double>
-    <x:Double x:Key="TitleBarContentMaxWidth">360</x:Double>
+    <x:Double x:Key="TitleBarContentMinWidth">360</x:Double>
     <Style BasedOn="{StaticResource DefaultTitleBarStyle}"
            TargetType="local:TitleBar" />
 
@@ -178,7 +178,7 @@
 
                         <ContentPresenter x:Name="PART_ContentPresenter"
                                           Grid.Column="5"
-                                          MinWidth="360"
+                                          MinWidth="{ThemeResource TitleBarContentMinWidth}"
                                           HorizontalAlignment="Stretch"
                                           VerticalAlignment="Center"
                                           HorizontalContentAlignment="Stretch"


### PR DESCRIPTION
There was no way for an app to override the TitleBarContentMinWidth - this is now configurable by using lightweight styling.