### PR TITLE
Fixed scheduled build workflow/job trigger conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main, 'rel/weekly' ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, 'rel/weekly' ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,10 @@ on:
         description: 'The end commit of the range to check for incremental builds.'
         type: string
         required: false
+      is_scheduled:
+        description: 'A boolean value that indicates whether this is a scheduled run.'
+        type: boolean
+        required: false
 
 env:
   DOTNET_VERSION: ${{ '9.0.x' }}
@@ -341,7 +345,7 @@ jobs:
 
   sign:
     needs: [package]
-    if: ${{ startsWith(github.ref, 'refs/heads/rel/') }}
+    if: ${{ startsWith(github.ref, 'refs/heads/rel/') || inputs.is_scheduled }}
     runs-on: windows-latest
     permissions:
       id-token: write # Required for requesting the JWT
@@ -406,7 +410,7 @@ jobs:
             ${{ github.workspace }}/packages/**/*.nupkg
 
   release:
-    if: ${{ startsWith(github.ref, 'refs/heads/rel/') }}
+    if: ${{ startsWith(github.ref, 'refs/heads/rel/') || inputs.is_scheduled }}
     needs: [sign]
     environment: nuget-release-gate # This gates this job until manually approved
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -68,4 +68,5 @@ jobs:
     with:
       commit_range_start: ${{ needs.tag-weekly-release.outputs.commit_range_start }}
       commit_range_end: ${{ needs.tag-weekly-release.outputs.commit_range_end }}
+      is_scheduled: true
     secrets: inherit


### PR DESCRIPTION
This PR is a follow-up to https://github.com/CommunityToolkit/Labs-Windows/pull/713 which:
- Cleans up extraneous `rel/weekly` references
- Adds a workflow variable to build.yml to identify when sign/release can run for scheduled releases, rather than just on `rel/*` branches. 