### PR TITLE
Remove version prop from TitleBar, everything auto-versioned by date now

### DIFF
--- a/components/TitleBar/src/CommunityToolkit.WinUI.Controls.TitleBar.csproj
+++ b/components/TitleBar/src/CommunityToolkit.WinUI.Controls.TitleBar.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ToolkitComponentName>TitleBar</ToolkitComponentName>
     <Description>This package contains TitleBar.</Description>
-    <Version>0.0.2</Version>
 
     <!-- Rns suffix is required for namespaces shared across projects. See https://github.com/CommunityToolkit/Labs-Windows/issues/152 -->
     <RootNamespace>CommunityToolkit.WinUI.Controls.TitleBarRns</RootNamespace>


### PR DESCRIPTION
Outlier missed in switch-over