### PR TITLE
Fix sign artifact mismatch in GitHub Actions workflow

### DIFF
--- a/.github/workflows/SignClientFileList.txt
+++ b/.github/workflows/SignClientFileList.txt
@@ -1,0 +1,1 @@
+**/CommunityToolkit.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -326,6 +326,15 @@ jobs:
             --username dummy --password ${{ secrets.DEVOPS_PACKAGE_PUSH_TOKEN }}
           dotnet nuget push "**/*.nupkg" --api-key dummy --source LabsFeed --skip-duplicate
 
+      - name: Upload Package List
+        uses: actions/upload-artifact@v4
+        if: ${{ (env.IS_PR == 'false' || github.event.pull_request.head.repo.full_name != github.repository) && env.HAS_BUILDABLE_COMPONENTS == 'true' }}
+        with:
+          name: nuget-list-${{ matrix.winui }}
+          if-no-files-found: error
+          path: |
+            ${{ github.workspace }}/.github/workflows/SignClientFileList.txt
+
       # if we're not doing a PR build (or it's a PR from a fork) then we upload our packages so we can sign as a separate job or have available to test.
       - name: Upload Packages as Artifacts
         uses: actions/upload-artifact@v4
@@ -402,7 +411,7 @@ jobs:
 
       - name: Upload Signed Packages as Artifacts (for release)
         uses: actions/upload-artifact@v4
-        if: ${{ env.IS_RELEASE == 'true' }}
+        if: ${{ startsWith(github.ref, 'refs/heads/rel/') || inputs.is_scheduled }}
         with:
           name: signed-nuget-packages-${{ matrix.winui }}
           if-no-files-found: error


### PR DESCRIPTION
The sign job was failing with 'Artifact not found for name: nuget-list-2'
because the Labs-Windows workflow was missing the upload step for the
nuget-list artifact that the sign job expected to download.

Changes made:
- Added missing SignClientFileList.txt containing '**/CommunityToolkit.*'
- Added upload step in package job to create nuget-list-{winui} artifacts
- Fixed conditional for signed package upload artifacts

This ensures both required artifacts are uploaded by the package job:
1. nuget-packages-winui{N} (the actual .nupkg files)
2. nuget-list-{N} (SignClientFileList.txt for signing)

The sign job should now successfully download both artifacts to proceed with signing.
