### PR TITLE
Use tag-based trigger for scheduled release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ env:
   COREHOST_TRACEFILE: corehosttrace.log
   IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
   IS_PR: ${{ startsWith(github.ref, 'refs/pull/') }}
-  IS_TAG: ${{ startsWith(github.ref, 'refs/tags/') }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -91,7 +90,7 @@ jobs:
           fetch-tags: true
 
       - name: Determine scheduled release commit range
-        if: ${{ env.IS_TAG }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         id: range
         shell: pwsh
         run: |
@@ -290,7 +289,7 @@ jobs:
           vs-version: '[17.9,)'
 
       - name: Determine scheduled release commit range
-        if: ${{ env.IS_TAG }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         id: range
         shell: pwsh
         run: |
@@ -301,7 +300,7 @@ jobs:
           
       - name: Get changed components
         run: |
-          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ env.PREV_TAG_COMMIT || github.event.before }} ${{ inputs.commit_range_end || github.event.after }})
+          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ env.PREV_TAG_COMMIT || github.event.before }} ${{ github.event.after || github.sha }})
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets "all" -WinUIMajorVersion ${{ matrix.winui }})
           echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,26 @@ jobs:
         shell: pwsh
         run: |
           # Previous weekly tag (2nd newest); fallback to main's HEAD
-          $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
-          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
+          $allTags = git tag --list 'release/weekly/*' --sort=-creatordate
+          Write-Host "[diag] Weekly tags (newest first):"
+          $i = 0
+          foreach ($t in $allTags) {
+            $len = if ($null -ne $t) { $t.Length } else { 0 }
+            Write-Host ("  [{0}] '{1}' len={2}" -f $i, $t, $len)
+            $i++
+          }
+          $prevTag = $allTags | Select-Object -Skip 1 -First 1
+          $prevType = if ($null -ne $prevTag) { $prevTag.GetType().FullName } else { '<null>' }
+          $prevLen  = if ($null -ne $prevTag) { $prevTag.Length } else { 0 }
+          Write-Host ("[diag] prevTag: null?={0} type={1} len={2} value=''{3}''" -f ($null -eq $prevTag), $prevType, $prevLen, $prevTag)
+          if ($prevTag -is [string]) {
+            $codes = [int[]][char[]]$prevTag
+            Write-Host ("[diag] prevTag char codes: {0}" -f ($codes -join ','))
+          }
+          $isEmpty = [string]::IsNullOrWhiteSpace($prevTag)
+          Write-Host ("[diag] IsNullOrWhiteSpace(prevTag)={0}" -f $isEmpty)
+          Write-Host ("[diag] Branch chosen -> {0}" -f ($isEmpty ? 'fallback: origin/main' : ("tag: {0}" -f $prevTag)))
+          $tagSha  = $isEmpty
             ? (git rev-parse 'origin/main').Trim()
             : (git rev-list -n 1 $prevTag).Trim()
           "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV
@@ -297,8 +315,26 @@ jobs:
         shell: pwsh
         run: |
           # Previous weekly tag (2nd newest); fallback to main's HEAD
-          $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
-          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
+          $allTags = git tag --list 'release/weekly/*' --sort=-creatordate
+          Write-Host "[diag] Weekly tags (newest first):"
+          $i = 0
+          foreach ($t in $allTags) {
+            $len = if ($null -ne $t) { $t.Length } else { 0 }
+            Write-Host ("  [{0}] '{1}' len={2}" -f $i, $t, $len)
+            $i++
+          }
+          $prevTag = $allTags | Select-Object -Skip 1 -First 1
+          $prevType = if ($null -ne $prevTag) { $prevTag.GetType().FullName } else { '<null>' }
+          $prevLen  = if ($null -ne $prevTag) { $prevTag.Length } else { 0 }
+          Write-Host ("[diag] prevTag: null?={0} type={1} len={2} value=''{3}''" -f ($null -eq $prevTag), $prevType, $prevLen, $prevTag)
+          if ($prevTag -is [string]) {
+            $codes = [int[]][char[]]$prevTag
+            Write-Host ("[diag] prevTag char codes: {0}" -f ($codes -join ','))
+          }
+          $isEmpty = [string]::IsNullOrWhiteSpace($prevTag)
+          Write-Host ("[diag] IsNullOrWhiteSpace(prevTag)={0}" -f $isEmpty)
+          Write-Host ("[diag] Branch chosen -> {0}" -f ($isEmpty ? 'fallback: origin/main' : ("tag: {0}" -f $prevTag)))
+          $tagSha  = $isEmpty
             ? (git rev-parse 'origin/main').Trim()
             : (git rev-list -n 1 $prevTag).Trim()
           "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,26 +96,8 @@ jobs:
         shell: pwsh
         run: |
           # Previous weekly tag (2nd newest); fallback to main's HEAD
-          $allTags = git tag --list 'release/weekly/*' --sort=-creatordate
-          Write-Host "[diag] Weekly tags (newest first):"
-          $i = 0
-          foreach ($t in $allTags) {
-            $len = if ($null -ne $t) { $t.Length } else { 0 }
-            Write-Host ("  [{0}] '{1}' len={2}" -f $i, $t, $len)
-            $i++
-          }
-          $prevTag = $allTags | Select-Object -Skip 1 -First 1
-          $prevType = if ($null -ne $prevTag) { $prevTag.GetType().FullName } else { '<null>' }
-          $prevLen  = if ($null -ne $prevTag) { $prevTag.Length } else { 0 }
-          Write-Host ("[diag] prevTag: null?={0} type={1} len={2} value=''{3}''" -f ($null -eq $prevTag), $prevType, $prevLen, $prevTag)
-          if ($prevTag -is [string]) {
-            $codes = [int[]][char[]]$prevTag
-            Write-Host ("[diag] prevTag char codes: {0}" -f ($codes -join ','))
-          }
-          $isEmpty = [string]::IsNullOrWhiteSpace($prevTag)
-          Write-Host ("[diag] IsNullOrWhiteSpace(prevTag)={0}" -f $isEmpty)
-          Write-Host ("[diag] Branch chosen -> {0}" -f ($isEmpty ? 'fallback: origin/main' : ("tag: {0}" -f $prevTag)))
-          $tagSha  = $isEmpty
+          $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
+          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
             ? (git rev-parse 'origin/main').Trim()
             : (git rev-list -n 1 $prevTag).Trim()
           "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV
@@ -315,26 +297,8 @@ jobs:
         shell: pwsh
         run: |
           # Previous weekly tag (2nd newest); fallback to main's HEAD
-          $allTags = git tag --list 'release/weekly/*' --sort=-creatordate
-          Write-Host "[diag] Weekly tags (newest first):"
-          $i = 0
-          foreach ($t in $allTags) {
-            $len = if ($null -ne $t) { $t.Length } else { 0 }
-            Write-Host ("  [{0}] '{1}' len={2}" -f $i, $t, $len)
-            $i++
-          }
-          $prevTag = $allTags | Select-Object -Skip 1 -First 1
-          $prevType = if ($null -ne $prevTag) { $prevTag.GetType().FullName } else { '<null>' }
-          $prevLen  = if ($null -ne $prevTag) { $prevTag.Length } else { 0 }
-          Write-Host ("[diag] prevTag: null?={0} type={1} len={2} value=''{3}''" -f ($null -eq $prevTag), $prevType, $prevLen, $prevTag)
-          if ($prevTag -is [string]) {
-            $codes = [int[]][char[]]$prevTag
-            Write-Host ("[diag] prevTag char codes: {0}" -f ($codes -join ','))
-          }
-          $isEmpty = [string]::IsNullOrWhiteSpace($prevTag)
-          Write-Host ("[diag] IsNullOrWhiteSpace(prevTag)={0}" -f $isEmpty)
-          Write-Host ("[diag] Branch chosen -> {0}" -f ($isEmpty ? 'fallback: origin/main' : ("tag: {0}" -f $prevTag)))
-          $tagSha  = $isEmpty
+          $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
+          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
             ? (git rev-parse 'origin/main').Trim()
             : (git rev-list -n 1 $prevTag).Trim()
           "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,7 @@ jobs:
         run: |
           # Previous weekly tag (2nd newest); fallback to main's HEAD
           $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
-          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
-            ? (git rev-parse 'origin/main').Trim()
-            : (git rev-list -n 1 $prevTag).Trim()
+          $tagSha = [string]::IsNullOrWhiteSpace($prevTag) ? (git rev-parse 'origin/main').Trim() : (git rev-list -n 1 $prevTag).Trim()
           "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV
           
       - name: Get changed components
@@ -298,9 +296,7 @@ jobs:
         run: |
           # Previous weekly tag (2nd newest); fallback to main's HEAD
           $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
-          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
-            ? (git rev-parse 'origin/main').Trim()
-            : (git rev-list -n 1 $prevTag).Trim()
+          $tagSha = [string]::IsNullOrWhiteSpace($prevTag) ? (git rev-parse 'origin/main').Trim() : (git rev-list -n 1 $prevTag).Trim()
           "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV
           
       - name: Get changed components

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           
       - name: Get changed components
         run: |
-          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ env.PREV_TAG_COMMIT || github.event.before }} ${{ github.ref || github.event.after }})
+          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ env.PREV_TAG_COMMIT || github.event.before }} ${{ github.sha || github.event.after }})
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets ${{ matrix.multitarget }} -WinUIMajorVersion ${{ matrix.winui }})
           echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,28 +9,13 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
+    tags: [ 'release/weekly/*' ]
   pull_request:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   merge_group:
-  
-  # Allow this workflow to be called as a reusable workflow
-  workflow_call:
-    inputs:
-      commit_range_start:
-        description: 'The start commit of the range to check for incremental builds.'
-        type: string
-        required: false
-      commit_range_end:
-        description: 'The end commit of the range to check for incremental builds.'
-        type: string
-        required: false
-      is_scheduled:
-        description: 'A boolean value that indicates whether this is a scheduled run.'
-        type: boolean
-        required: false
 
 env:
   DOTNET_VERSION: ${{ '9.0.x' }}
@@ -40,6 +25,7 @@ env:
   COREHOST_TRACEFILE: corehosttrace.log
   IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
   IS_PR: ${{ startsWith(github.ref, 'refs/pull/') }}
+  IS_TAG: ${{ startsWith(github.ref, 'refs/tags/') }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -59,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ inputs.commit_range_end || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -100,13 +86,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ inputs.commit_range_end || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Determine scheduled release commit range
+        if: ${{ env.IS_TAG }}
+        id: range
+        shell: pwsh
+        run: |
+          # Previous weekly tag (2nd newest); fallback to main's HEAD
+          $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
+          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
+            ? (git rev-parse 'origin/main').Trim()
+            : (git rev-list -n 1 $prevTag).Trim()
+          "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV
           
       - name: Get changed components
         run: |
-          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ inputs.commit_range_start || github.event.before }} ${{ inputs.commit_range_end || github.event.after }})
+          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ env.PREV_TAG_COMMIT || github.event.before }} ${{ github.ref || github.event.after }})
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets ${{ matrix.multitarget }} -WinUIMajorVersion ${{ matrix.winui }})
           echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV
@@ -266,7 +264,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ inputs.commit_range_end || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
           
@@ -292,10 +290,22 @@ jobs:
         uses: microsoft/setup-msbuild@v2
         with:
           vs-version: '[17.9,)'
-            # Get changed components
+
+      - name: Determine scheduled release commit range
+        if: ${{ env.IS_TAG }}
+        id: range
+        shell: pwsh
+        run: |
+          # Previous weekly tag (2nd newest); fallback to main's HEAD
+          $prevTag = git tag --list 'release/weekly/*' --sort=-creatordate | Select-Object -Skip 1 -First 1
+          $tagSha  = [string]::IsNullOrWhiteSpace($prevTag)
+            ? (git rev-parse 'origin/main').Trim()
+            : (git rev-list -n 1 $prevTag).Trim()
+          "PREV_TAG_COMMIT=$tagSha" >> $env:GITHUB_ENV
+          
       - name: Get changed components
         run: |
-          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ inputs.commit_range_start || github.event.before }} ${{ inputs.commit_range_end || github.event.after }})
+          $changedComponents = $(./tooling/Get-Changed-Components.ps1 ${{ env.PREV_TAG_COMMIT || github.event.before }} ${{ inputs.commit_range_end || github.event.after }})
           $buildableChangedComponents = $(./tooling/MultiTarget/Filter-Supported-Components.ps1 -Components $changedComponents -MultiTargets "all" -WinUIMajorVersion ${{ matrix.winui }})
           echo "CHANGED_COMPONENTS_LIST=$(($buildableChangedComponents | ForEach-Object { "$_" }) -join ',')" >> $env:GITHUB_ENV
           echo "HAS_BUILDABLE_COMPONENTS=$($buildableChangedComponents.Count -gt 0)" >> $env:GITHUB_ENV
@@ -354,7 +364,7 @@ jobs:
 
   sign:
     needs: [package]
-    if: ${{ startsWith(github.ref, 'refs/heads/rel/') || inputs.is_scheduled }}
+    if: ${{ startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/') }}
     runs-on: windows-latest
     permissions:
       id-token: write # Required for requesting the JWT
@@ -411,7 +421,7 @@ jobs:
 
       - name: Upload Signed Packages as Artifacts (for release)
         uses: actions/upload-artifact@v4
-        if: ${{ startsWith(github.ref, 'refs/heads/rel/') || inputs.is_scheduled }}
+        if: ${{ startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/') }}
         with:
           name: signed-nuget-packages-${{ matrix.winui }}
           if-no-files-found: error
@@ -419,7 +429,7 @@ jobs:
             ${{ github.workspace }}/packages/**/*.nupkg
 
   release:
-    if: ${{ startsWith(github.ref, 'refs/heads/rel/') || inputs.is_scheduled }}
+    if: ${{ startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/') }}
     needs: [sign]
     environment: nuget-release-gate # This gates this job until manually approved
     runs-on: ubuntu-latest
@@ -469,7 +479,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ inputs.commit_range_end || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      commit_range_start: ${{ steps.range.outputs.commit_range_start }}
-      commit_range_end: ${{ steps.range.outputs.commit_range_end }}
 
     steps:
       - name: Checkout repository
@@ -37,36 +34,4 @@ jobs:
           TAG="release/weekly/$(date +%y%m%d)"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
-
-      - name: Determine commit range
-        id: range
-        run: |
-          # New tag we just created
-          NEW_TAG=${{ steps.create-tag.outputs.TAG }}
-
-          # Find the previous tag (sorted newest‑first)
-          PREV_TAG=$(git tag --list "release/weekly/*" --sort=-creatordate | sed -n '2p')
-
-          # If we’re on the very first tag, fall back to main
-          if [ -z "$PREV_TAG" ]; then
-            PREV_TAG=main
-          fi
-
-          # Resolve the commit hashes
-          START_COMMIT=$(git rev-parse "$PREV_TAG")
-          END_COMMIT=$(git rev-parse "$NEW_TAG")
-
-          # Export them as workflow outputs
-          echo "commit_range_start=$START_COMMIT" >> $GITHUB_OUTPUT
-          echo "commit_range_end=$END_COMMIT" >> $GITHUB_OUTPUT
-
-  # Then trigger the build workflow with the commit range.
-  trigger-build:
-    needs: tag-weekly-release
-    uses: ./.github/workflows/build.yml
-    with:
-      commit_range_start: ${{ needs.tag-weekly-release.outputs.commit_range_start }}
-      commit_range_end: ${{ needs.tag-weekly-release.outputs.commit_range_end }}
-      is_scheduled: true
-    secrets: inherit
+          


### PR DESCRIPTION
Refactor scheduled release build to trigger based on tags pushed in cron workflow instead of a reusable workflow.