### PR TITLE
Adding a default Config to MarkdownTextBlock

### DIFF
--- a/components/MarkdownTextBlock/samples/MarkdownTextBlockLiveEditorSample.xaml
+++ b/components/MarkdownTextBlock/samples/MarkdownTextBlockLiveEditorSample.xaml
@@ -26,7 +26,6 @@
             <controls:MarkdownTextBlock x:Name="MarkdownTextBlock"
                                         Grid.Column="0"
                                         Margin="0,0,6,0"
-                                        Config="{x:Bind MarkdownConfig, Mode=OneTime}"
                                         DisableHtml="{x:Bind DisableHtml, Mode=OneWay}"
                                         Text="{x:Bind MarkdownTextBox.Text, Mode=OneWay}"
                                         UseAutoLinks="{x:Bind UseAutoLinks, Mode=OneWay}"

--- a/components/MarkdownTextBlock/samples/MarkdownTextBlockLiveEditorSample.xaml.cs
+++ b/components/MarkdownTextBlock/samples/MarkdownTextBlockLiveEditorSample.xaml.cs
@@ -20,18 +20,9 @@ namespace MarkdownTextBlockExperiment.Samples;
 [ToolkitSample(id: nameof(MarkdownTextBlockLiveEditorSample), "Live Editor", description: $"An interactive live editor for the {nameof(CommunityToolkit.WinUI.Controls.MarkdownTextBlock)} control. Type markdown and see it rendered in real-time.")]
 public sealed partial class MarkdownTextBlockLiveEditorSample : Page
 {
-    private MarkdownConfig _config;
-
-    public MarkdownConfig MarkdownConfig
-    {
-        get => _config;
-        set => _config = value;
-    }
-
     public MarkdownTextBlockLiveEditorSample()
     {
         this.InitializeComponent();
-        _config = new MarkdownConfig();
         MarkdownTextBox.Text = """
             # Hello World
 

--- a/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
+++ b/components/MarkdownTextBlock/src/MarkdownTextBlock.Properties.cs
@@ -15,7 +15,7 @@ public partial class MarkdownTextBlock
         nameof(Config),
         typeof(MarkdownConfig),
         typeof(MarkdownTextBlock),
-        new PropertyMetadata(null, OnConfigChanged)
+        new PropertyMetadata(new MarkdownConfig(), OnConfigChanged)
     );
 
     /// <summary>


### PR DESCRIPTION
To make this work:

```xml
<controls:MarkdownTextBlock Text="This is text"/>
```

A default `MarkdigConfig` had to be set in code-behind. Even when not making any changes to the config. This is a regression vs the `MarkdownTextBlock` from CommunityToolkit 7.x.

This PR:
- Adds a default config to the property.
- Removes the setting of the config in code-behind from the live editor to validate that it works