### PR TITLE
Install .NET 6 SDK to re-enable XAML Styler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,12 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # .NET 6 SDK is required for xamlstyler.console to run.
+      - name: Install .NET SDK v6
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
       - name: Install .NET SDK v${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
   # Build both Uno.UI/WinUI2/UWP and Uno.WinUI/WinUI3/WindowsAppSDK versions of our packages using a matrix
   build:
     needs: [Xaml-Style-Check]
-    runs-on: windows-latest
+    runs-on: windows-latest-large
 
     # See https://docs.github.com/actions/using-jobs/using-a-matrix-for-your-jobs
     strategy:
@@ -242,7 +242,7 @@ jobs:
           dotnet-dump analyze ${{ steps.filter.outputs.dump_files }} -c "clrstack" -c "pe -lines" -c "exit"
 
   package:
-    runs-on: windows-latest
+    runs-on: windows-latest-large
     needs: [build]
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.


### PR DESCRIPTION

<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! ⚠ -->

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

## Fixes

This PR fixes the error observed at [this CI run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/17837578593/job/50718577918) by installing the .NET 6 SDK explicitly.

Log for failed CI step:
```
Run powershell -version 5.1 -command "./ApplyXamlStyling.ps1 -Passive" -ErrorAction Stop
Use 'Help .\ApplyXamlStyling.ps1' for more info or '-Main' to run against all files.

Restoring dotnet tools...
Tool 'uno.check' (version '1.27.4') was restored. Available commands: uno-check
Tool 'xamlstyler.console' (version '3.2206.4') was restored. Available commands: xstyler
Tool 'microsoft.visualstudio.slngen.tool' (version '12.0.13') was restored. Available commands: slngen

Restore was successful.
Checking all files (passively)
You must install or update .NET to run this application.

App: C:\Users\runneradmin\.nuget\packages\xamlstyler.console\3.2206.4\tools\net6.0\any\xstyler.dll
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  8.0.6 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  8.0.19 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  8.0.20 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  9.0.6 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  9.0.8 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  9.0.9 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.0&arch=x64&rid=win-x64&os=win10
Error: Process completed with exit code 1.
```

## Other information

See also https://github.com/actions/runner-images/issues/12241
