### PR TITLE
Remove net6.0 install for Xaml-Style-Check CI job, update xamlstyler

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "xamlstyler.console": {
-      "version": "3.2206.4",
+      "version": "3.2501.8",
       "commands": [
         "xstyler"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # .NET 6 SDK is required for xamlstyler.console to run.
-      - name: Install .NET SDK v6
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
-
       - name: Install .NET SDK v${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
This PR reverts the changes made in https://github.com/CommunityToolkit/Windows/pull/729 and instead updates the XamlStyler version to the latest to resolve the build errors detailed in [this comment](https://github.com/CommunityToolkit/Windows/pull/729#issue-3434627302).

- Bump xamlstyler.console from 3.2206.4 to 3.2501.8
- Remove .NET 6 SDK installation step from build workflow
