### PR TITLE
Use double star for tag filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-    tags: [ 'release/weekly/*' ]
+    tags: [ 'release/weekly/**' ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
The PR attempts to fix our tag-based scheduled release build workflow not triggering on the tag ref when the tag is pushed by changing the filter used in the `push` event.

See also:
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore
- https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#push