### PR TITLE
MarkdownTextBlock: Add guard against NRE in MyCodeBlock and HtmlBlockRenderer

### DIFF
--- a/components/MarkdownTextBlock/src/Renderers/ObjectRenderers/HtmlBlockRenderer.cs
+++ b/components/MarkdownTextBlock/src/Renderers/ObjectRenderers/HtmlBlockRenderer.cs
@@ -15,14 +15,17 @@ internal class HtmlBlockRenderer : UWPObjectRenderer<HtmlBlock>
         if (obj == null) throw new ArgumentNullException(nameof(obj));
 
         var stringBuilder = new StringBuilder();
-        foreach (var line in obj.Lines.Lines)
+        if (obj.Lines.Lines != null)
         {
-            var lineText = line.Slice.ToString().Trim();
-            if (String.IsNullOrWhiteSpace(lineText))
+            foreach (var line in obj.Lines.Lines)
             {
-                continue;
+                var lineText = line.Slice.ToString().Trim();
+                if (String.IsNullOrWhiteSpace(lineText))
+                {
+                    continue;
+                }
+                stringBuilder.AppendLine(lineText);
             }
-            stringBuilder.AppendLine(lineText);
         }
 
         var html = Regex.Replace(stringBuilder.ToString(), @"\t|\n|\r", "", RegexOptions.Compiled);

--- a/components/MarkdownTextBlock/src/TextElements/MyCodeBlock.cs
+++ b/components/MarkdownTextBlock/src/TextElements/MyCodeBlock.cs
@@ -75,20 +75,23 @@ internal class MyCodeBlock : IAddChild
         {
 #endif
 
-        foreach (var line in codeBlock.Lines.Lines)
+        if (codeBlock.Lines.Lines != null)
         {
-            var paragraph = new Paragraph();
-            var lineString = line.ToString();
-            if (!String.IsNullOrWhiteSpace(lineString))
+            foreach (var line in codeBlock.Lines.Lines)
             {
-                paragraph.Inlines.Add(new Run() { Text = lineString });
+                var paragraph = new Paragraph();
+                var lineString = line.ToString();
+                if (!String.IsNullOrWhiteSpace(lineString))
+                {
+                    paragraph.Inlines.Add(new Run() { Text = lineString });
+                }
+                richTextBlock.Blocks.Add(paragraph);
             }
-            richTextBlock.Blocks.Add(paragraph);
+
+            border.Child = richTextBlock;
+            container.Child = border;
+            _paragraph.Inlines.Add(container);
         }
-        
-        border.Child = richTextBlock;
-        container.Child = border;
-        _paragraph.Inlines.Add(container);
     }
 
     public void AddChild(IAddChild child) {}


### PR DESCRIPTION
This PR adds a null guard for `StringLineGroup.Lines` to prevent iteration when it is null.  
- Applied in `MyCodeBlock`, where it caused a crash.  
- Added defensively in `HtmlBlockRenderer`.  

**References:**  
- https://github.com/CommunityToolkit/Labs-Windows/issues/606#issuecomment-3361292065  
- https://github.com/CommunityToolkit/Labs-Windows/issues/606#issuecomment-3361785009
