### PR TITLE
Fix version format for weekly release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
 
     env:
       MULTI_TARGET_DIRECTORY: tooling/MultiTarget
-      VERSION_PROPERTY: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/')) && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
+      VERSION_PROPERTY: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/release/')) && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -266,7 +266,7 @@ jobs:
         winui: [0, 2, 3]
 
     env:
-      VERSION_PROPERTY: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/')) && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
+      VERSION_PROPERTY: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/release/')) && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
 
     steps:
       - name: Install .NET SDK v${{ env.DOTNET_VERSION }}


### PR DESCRIPTION
## Problem

Weekly release packages have malformed version suffixes due to incorrect `VERSION_PROPERTY` logic in the build workflow.

**Example from [run 18109399189](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/18109399189) (Sept 29, 2025):**
- **Actual:** `CommunityToolkit.Labs.WinUI.Controls.Shimmer.0.1.250929-pull-.2302.nupkg`
- **Expected:** `CommunityToolkit.Labs.WinUI.Controls.Shimmer.0.1.250929-build.2302.nupkg`

All 12 packages in the [Sept 29 weekly release run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/18109399189) had the malformed `pull-.RUNNUMBER` suffix instead of the correct `build.RUNNUMBER` format.

## Root Cause

The `VERSION_PROPERTY` environment variable in `build.yml` uses conditional logic to determine version suffix format:

```yaml
VERSION_PROPERTY: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/')) && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
```

This condition checks:
- If `main` or `rel/*` branch → use `build.RUNNUMBER`
- Otherwise → use `pull-PRNUMBER.RUNNUMBER`

Weekly release tags have refs like `refs/tags/release/weekly/250929`, which don't match either condition, so they fall through to the pull request format. Since `github.event.number` is null for tag pushes, the result is `pull-.RUNNUMBER`.

## Solution

Add tag detection to the condition so release tags use the same format as main branch builds:

```yaml
VERSION_PROPERTY: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/release/')) && format('build.{0}', github.run_number) || format('pull-{0}.{1}', github.event.number, github.run_number) }}
```

This change is applied in both the `build` job (line 85) and `package` job (line 269) to ensure consistent version formatting throughout the workflow.

## Testing

This fix can be validated:
1. **Next automated weekly release:** Wednesday, October 8, 2025 scheduled run
2. **Manual testing:** Trigger the `scheduled-releases` workflow manually via Actions UI
3. **Expected result:** Package names should have `build.RUNNUMBER` suffix instead of `pull-.RUNNUMBER`

## Related

- Part of incremental build improvements following PR #744
- Follow-up work still needed for missing component packages (separate investigation)
- Completes the version format portion of secondary CI issues

## Evidence

Downloaded artifacts from [run 18109399189](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/18109399189) confirmed all packages had malformed version suffix. Example packages affected: CanvasLayout, CanvasView, DataTable, MarkdownTextBlock, Marquee, OpacityMaskView, Shimmer, TitleBar, TokenView, DependencyPropertyGenerator, RivePlayer, TransitionHelper.
