### PR TITLE
Fix Ribbon control PackageId evaluation order

### DIFF
--- a/components/Ribbon/src/CommunityToolkit.WinUI.Controls.Ribbon.csproj
+++ b/components/Ribbon/src/CommunityToolkit.WinUI.Controls.Ribbon.csproj
@@ -10,12 +10,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <!-- Sets this up as a toolkit component's source project -->
+  <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
+
   <PropertyGroup>
     <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
   </PropertyGroup>
   
-  <!-- Sets this up as a toolkit component's source project -->
-  <Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
   <ItemGroup>
     <UpToDateCheckInput Remove="RibbonStyle.xaml" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Fixes the Ribbon control not publishing to NuGet feeds by correcting the evaluation order of `PackageId` and the `Import` statement in Ribbon.csproj.

Fixes #739

## Problem

The Ribbon control has been missing from all NuGet artifact sets (WinUI 0, 2, and 3) in weekly CI releases. Investigation revealed that `PackageId` was being evaluated before importing the props file that defines `$(PackageIdVariant)`, resulting in malformed package identifiers like `CommunityToolkit..Controls.Ribbon` (note the double dot from the empty variable).

## Root Cause

In `Ribbon.csproj`, the `PackageId` PropertyGroup appeared **before** the Import statement:

```xml
<PropertyGroup>
  <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
</PropertyGroup>

<Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />
```

Since MSBuild evaluates properties in document order, `$(PackageIdVariant)` was undefined when `PackageId` was evaluated. The variable is only defined after importing `ToolkitComponent.SourceProject.props` (via the chain: ToolkitComponent.SourceProject.props → Library.props → WinUI.TargetVersion.props).

## Solution

Move the Import statement to appear **before** the PackageId PropertyGroup:

```xml
<Import Project="$(ToolingDirectory)\ToolkitComponent.SourceProject.props" />

<PropertyGroup>
  <PackageId>$(PackageIdPrefix).$(PackageIdVariant).Controls.$(ToolkitComponentName)</PackageId>
</PropertyGroup>
```

This ensures `$(PackageIdVariant)` is defined when `PackageId` is evaluated.

## Validation

This fix aligns Ribbon with the established pattern used by **all other controls**:
- ✅ Shimmer: [Import line 12](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/Shimmer/src/CommunityToolkit.WinUI.Controls.Shimmer.csproj#L12) → [PackageId line 18](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/Shimmer/src/CommunityToolkit.WinUI.Controls.Shimmer.csproj#L18)
- ✅ CanvasLayout: [Import line 11](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/CanvasLayout/src/CommunityToolkit.WinUI.Controls.CanvasLayout.csproj#L11) → [PackageId line 14](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/CanvasLayout/src/CommunityToolkit.WinUI.Controls.CanvasLayout.csproj#L14)
- ✅ DataTable: [Import line 12](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/DataTable/src/CommunityToolkit.WinUI.Controls.DataTable.csproj#L12) → [PackageId line 15](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/DataTable/src/CommunityToolkit.WinUI.Controls.DataTable.csproj#L15)
- ✅ MarkdownTextBlock: [Import line 13](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/MarkdownTextBlock/src/CommunityToolkit.WinUI.Controls.MarkdownTextBlock.csproj#L13) → [PackageId line 16](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/MarkdownTextBlock/src/CommunityToolkit.WinUI.Controls.MarkdownTextBlock.csproj#L16)
- ✅ TitleBar: [Import line 10](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/TitleBar/src/CommunityToolkit.WinUI.Controls.TitleBar.csproj#L10) → [PackageId line 13](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/TitleBar/src/CommunityToolkit.WinUI.Controls.TitleBar.csproj#L13)
- ✅ OpacityMaskView: [Import line 13](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/OpacityMaskView/src/CommunityToolkit.WinUI.Controls.OpacityMaskView.csproj#L13) → [PackageId line 16](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/OpacityMaskView/src/CommunityToolkit.WinUI.Controls.OpacityMaskView.csproj#L16)
- ❌ Ribbon: [PackageId line 14](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/Ribbon/src/CommunityToolkit.WinUI.Controls.Ribbon.csproj#L14) → [Import line 18](https://github.com/CommunityToolkit/Labs-Windows/blob/main/components/Ribbon/src/CommunityToolkit.WinUI.Controls.Ribbon.csproj#L18) (FIXED in this PR)

### Control Experiment

Notably, PR #719 (commit 4e428007) added `PackageId` to both Ribbon and OpacityMaskView in the **same commit**:
- **OpacityMaskView**: Import added first, then PackageId → ✅ Works (published successfully)
- **Ribbon**: PackageId added before existing Import → ❌ Failed (never published)

This demonstrates that placement order is the causative factor.

## Testing

- Verified all other controls follow consistent Import → PackageId pattern
- CI weekly release will validate .nupkg generation and publication

## Impact

- Low risk: 3-line change, no logic modifications
- Aligns with established pattern across all other controls
- Fixes missing Ribbon packages in NuGet feeds
