### PR TITLE
Fix scheduled release CI trigger and add sparse release notes

### DIFF
--- a/.github/workflows/scheduled-releases.yml
+++ b/.github/workflows/scheduled-releases.yml
@@ -18,21 +18,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Use a token with write permissions to push to the branch
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0 # Fetch all history for merging
+          fetch-depth: 0 # Fetch all history for tags
 
       - name: Create release
         id: create-release
         run: |
           # Date in the format YYMMDD
           TAG="release/weekly/$(date +%y%m%d)"
+          
+          # Get previous weekly tag for sparse release notes
+          PREV_TAG=$(git tag --list 'release/weekly/*' --sort=-creatordate | head -n 1)
+          
           # gh release create will automatically create the tag if it doesn't exist
           # This triggers the build workflow's tag listener, unlike git tag + git push
           # which doesn't trigger workflows when done by Actions tokens
           gh release create "$TAG" \
             --title "Weekly Release $(date +%y%m%d)" \
             --generate-notes \
+            --notes-start-tag "$PREV_TAG" \
+            --fail-on-no-commits \
             --prerelease
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}          


### PR DESCRIPTION
Attempts to fix the issue where scheduled weekly releases don't trigger CI builds.

## Problem

Release events created by workflows using `GITHUB_TOKEN` don't trigger other workflows (GitHub Actions security policy to prevent recursive workflow triggering).

## Solution

1. **Remove explicit token references** - Let GitHub Actions handle authentication automatically instead of explicitly setting `GH_TOKEN` or `GITHUB_TOKEN` in env
2. **Add `--notes-start-tag`** - Generate sparse release notes comparing only against previous weekly tag (prevents pinging everyone with full history)
3. **Add `--fail-on-no-commits`** - Prevent empty releases when no work has been done since last release

## Changes

- Modified `.github/workflows/scheduled-releases.yml`
- Removed `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` block
- Added logic to find previous weekly tag
- Added `--notes-start-tag "$PREV_TAG"` to `gh release create` command
- Added `--fail-on-no-commits` flag

## Testing

Can be tested via:
- Manual trigger: `workflow_dispatch` on Actions tab
- Automated: Wait for next Wednesday's scheduled run (Oct 23)

## Related

- Issue: Scheduled releases not triggering CI builds (discovered Oct 9 sync)
- PR #744 - Original release trigger fix attempt (switched from tag to release events, but didn't trigger release build)

See also
- https://cli.github.com/manual/gh_release_create
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
- https://docs.github.com/en/actions/tutorials/authenticate-with-github_token