### PR TITLE
Add netstandard (winui 0) to sign and release matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,7 +391,7 @@ jobs:
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them both to run to completion.
       matrix:
-        winui: [2, 3]
+        winui: [0, 2, 3]
 
     steps:
       - name: Install .NET SDK v${{ env.DOTNET_VERSION }}
@@ -456,7 +456,7 @@ jobs:
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them both to run to completion.
       matrix:
-        winui: [2, 3]
+        winui: [0, 2, 3]
 
     steps:
       - name: Install .NET SDK v${{ env.DOTNET_VERSION }}


### PR DESCRIPTION
## Summary

Fixes matrix mismatch causing netstandard-only packages to be built but never signed or released.

## Problem

The `build.yml` workflow has a matrix inconsistency across jobs:

- **Package job** matrix: `winui: [0, 2, 3]` (includes netstandard)
- **Sign job** matrix: `winui: [2, 3]` (excludes netstandard) 
- **Release job** matrix: `winui: [2, 3]` (excludes netstandard)

This causes netstandard-only components like `Extensions.DependencyInjection` to be built and packaged (creating `nuget-packages-winui0` artifacts) but never processed by downstream sign/release jobs. The packages are orphaned after the package job completes.

## Root Cause

The sign and release jobs were added by copying infrastructure from the mainline Windows Community Toolkit repository. Since mainline has no netstandard-only components, the copied code used `winui: [2, 3]`. Labs-Windows requires `[0, 2, 3]` to match its existing package job that supports netstandard-only components.

## Solution

This PR adds `0` to both matrices to match Labs' requirements:

**Sign job** (line ~394):
```yaml
    matrix:
-     winui: [2, 3]
+     winui: [0, 2, 3]
```

**Release job** (line ~458):
```yaml
    matrix:
-     winui: [2, 3]
+     winui: [0, 2, 3]
```

The signing and release logic already handles packages generically using `**/*.nupkg` patterns, so no additional changes are needed.

## Impact

- ✅ Extensions.DependencyInjection packages will now be signed and released to NuGet.org
- ✅ Future netstandard-only components will follow the complete pipeline
- ✅ No changes to existing WinUI 2/3 behavior (additive change only)

## Testing Recommendations

1. Create manual test tag (e.g., `release/weekly/251101`) 
2. Verify all three sign matrix jobs complete (winui 0, 2, 3)
3. Verify all three release matrix jobs complete (winui 0, 2, 3)
4. Verify Extensions.DependencyInjection appears on NuGet.org
5. Verify existing WinUI 2/3 packages still release correctly

## Related

- Recent CI work: #757 (manual tag versioning fix)
- Component verification: Extensions.DependencyInjection is the only current netstandard-only component ([search results](https://github.com/search?q=repo%3ACommunityToolkit%2FLabs-Windows%20%20%3CMultiTarget%3Enetstandard%3B%3C%2FMultiTarget%3E&type=code))
