### PR TITLE
Remove support for case where the DataRow is descendant of a Grid or DataTable

### DIFF
--- a/components/DataTable/src/DataTable/DataRow.cs
+++ b/components/DataTable/src/DataTable/DataRow.cs
@@ -63,9 +63,6 @@ public partial class DataRow : Panel
             _isTreeView = itemsPresenter.FindAscendant<TreeView>() is TreeView;
         }
 
-        // 1b. If we can't find the ItemsPresenter, then we reach up outside to find the next thing we could use as a parent
-        panel ??= this.FindAscendant<Panel>(static (element) => element is Grid or DataTable);
-
         // Cache actual datatable reference
         if (panel is DataTable table)
         {


### PR DESCRIPTION
Separate PR from #781

The removed logic would have been useless or more harmful, because of the reasons:

1) `DataTable` control is designed to represent 'header' of a table, not for containing the list of `DataRow`s.
2) `Grid` control is often used to lay out other controls rather than constructing a table, so there was possibilities that completely unrelated `Grid`s would have been caught as a parent.