### PR TITLE
Prevent to focus DataColumn itself by default

### DIFF
--- a/components/DataTable/src/DataTable/DataColumn.xaml
+++ b/components/DataTable/src/DataTable/DataColumn.xaml
@@ -18,6 +18,7 @@
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+            <Setter Property="IsTabStop" Value="False" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="controls:DataColumn">


### PR DESCRIPTION
Separate PR from #781

From the design concept, `DataColumn` control simply provides a space for the header content, so it should not interact with keyboard operations by default. If focusable something is actually needed, `DataTable` users can place any controls like a button there.
