### PR TITLE
Add internal methods in DataColumn

### DIFF
--- a/components/DataTable/src/DataTable/DataColumn.cs
+++ b/components/DataTable/src/DataTable/DataColumn.cs
@@ -16,6 +16,8 @@ public partial class DataColumn : ContentControl
 
     private WeakReference<DataTable>? _parent;
 
+    internal DataTable? DataTable => _parent?.TryGetTarget(out DataTable? parent) == true ? parent : null;
+
     /// <summary>
     /// Gets or sets the width of the largest child contained within the visible <see cref="DataRow"/>s of the <see cref="DataTable"/>.
     /// </summary>
@@ -25,6 +27,12 @@ public partial class DataColumn : ContentControl
     /// Gets or sets the internal copy of the <see cref="DesiredWidth"/> property to be used in calculations, this gets manipulated in Auto-Size mode.
     /// </summary>
     internal GridLength CurrentWidth { get; private set; }
+
+    internal bool IsAbsolute => CurrentWidth.IsAbsolute;
+
+    internal bool IsAuto => CurrentWidth.IsAuto;
+
+    internal bool IsStar => CurrentWidth.IsStar;
 
     /// <summary>
     /// Gets or sets whether the column can be resized by the user.
@@ -118,10 +126,6 @@ public partial class DataColumn : ContentControl
         CurrentWidth = new(this.ActualWidth);
 
         // Notify the rest of the table to update
-        if (_parent?.TryGetTarget(out DataTable? parent) == true
-            && parent != null)
-        {
-            parent.ColumnResized();
-        }
+        DataTable?.ColumnResized();
     }
 }

--- a/components/DataTable/src/DataTable/DataColumn.cs
+++ b/components/DataTable/src/DataTable/DataColumn.cs
@@ -16,7 +16,8 @@ public partial class DataColumn : ContentControl
 
     private WeakReference<DataTable>? _parent;
 
-    internal DataTable? DataTable => _parent?.TryGetTarget(out DataTable? parent) == true ? parent : null;
+    // Pass-thru convenience helper to get reference from WeakReference; computed each time, do not store result!
+    private DataTable? DataTable => _parent?.TryGetTarget(out DataTable? parent) == true ? parent : null;
 
     /// <summary>
     /// Gets or sets the width of the largest child contained within the visible <see cref="DataRow"/>s of the <see cref="DataTable"/>.

--- a/components/DataTable/src/DataTable/DataTable.cs
+++ b/components/DataTable/src/DataTable/DataTable.cs
@@ -58,11 +58,11 @@ public partial class DataTable : Panel
         // We only need to measure elements that are visible
         foreach (DataColumn column in elements)
         {
-            if (column.CurrentWidth.IsStar)
+            if (column.IsStar)
             {
                 proportionalUnits += column.DesiredWidth.Value;
             }
-            else if (column.CurrentWidth.IsAbsolute)
+            else if (column.IsAbsolute)
             {
                 fixedWidth += column.DesiredWidth.Value;
             }
@@ -76,11 +76,11 @@ public partial class DataTable : Panel
 
         foreach (DataColumn column in elements)
         {
-            if (column.CurrentWidth.IsStar)
+            if (column.IsStar)
             {
                 column.Measure(new Size(proportionalAmount * column.CurrentWidth.Value, availableSize.Height));
             }
-            else if (column.CurrentWidth.IsAbsolute)
+            else if (column.IsAbsolute)
             {
                 column.Measure(new Size(column.CurrentWidth.Value, availableSize.Height));
             }
@@ -120,11 +120,11 @@ public partial class DataTable : Panel
         // We only need to measure elements that are visible
         foreach (DataColumn column in elements)
         {
-            if (column.CurrentWidth.IsStar)
+            if (column.IsStar)
             {
                 proportionalUnits += column.CurrentWidth.Value;
             }
-            else if (column.CurrentWidth.IsAbsolute)
+            else if (column.IsAbsolute)
             {
                 fixedWidth += column.CurrentWidth.Value;
             }
@@ -143,12 +143,12 @@ public partial class DataTable : Panel
 
         foreach (DataColumn column in elements)
         {
-            if (column.CurrentWidth.IsStar)
+            if (column.IsStar)
             {
                 width = proportionalAmount * column.CurrentWidth.Value;
                 column.Arrange(new Rect(x, 0, width, finalSize.Height));
             }
-            else if (column.CurrentWidth.IsAbsolute)
+            else if (column.IsAbsolute)
             {
                 width = column.CurrentWidth.Value;
                 column.Arrange(new Rect(x, 0, width, finalSize.Height));


### PR DESCRIPTION
Separate PR from #781

Currently there are three `DataColumn` types for the layout logic. I'll add two more types for later improvement.