### PR TITLE
Update Microsoft.WindowsAppSDK to 1.8 stable

### DIFF
--- a/components/Adorners/samples/Dependencies.props
+++ b/components/Adorners/samples/Dependencies.props
@@ -11,11 +11,11 @@
 <Project>
   <!-- WinUI 2 / UWP / Uno -->
   <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk / Uno -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 </Project>

--- a/components/Adorners/samples/Dependencies.props
+++ b/components/Adorners/samples/Dependencies.props
@@ -11,11 +11,11 @@
 <Project>
   <!-- WinUI 2 / UWP / Uno -->
   <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk / Uno -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260402-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/Adorners/src/Dependencies.props
+++ b/components/Adorners/src/Dependencies.props
@@ -11,15 +11,15 @@
 <Project>
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 </Project>

--- a/components/Adorners/src/Dependencies.props
+++ b/components/Adorners/src/Dependencies.props
@@ -11,15 +11,15 @@
 <Project>
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260402-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260402-preview2"/>
     </ItemGroup>
 </Project>

--- a/components/CanvasView/src/Dependencies.props
+++ b/components/CanvasView/src/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 </Project>

--- a/components/CanvasView/src/Dependencies.props
+++ b/components/CanvasView/src/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Helpers" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.3.260402-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/ColorAnalyzer/samples/Dependencies.props
+++ b/components/ColorAnalyzer/samples/Dependencies.props
@@ -12,13 +12,13 @@
     <!-- WinUI 2 -->
     <ItemGroup Condition="'$(WinUIMajorVersion)' == '2'">
         <!-- <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/> -->
-      <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
-      <PackageReference Include="CommunityToolkit.Uwp.Controls.ColorPicker" Version="8.2.250402"/>
+      <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+      <PackageReference Include="CommunityToolkit.Uwp.Controls.ColorPicker" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
   
     <!-- WinUI 3 -->
     <ItemGroup Condition="'$(WinUIMajorVersion)' == '3'">
-      <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
-      <PackageReference Include="CommunityToolkit.WinUI.Controls.ColorPicker" Version="8.2.250402"/>
+      <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+      <PackageReference Include="CommunityToolkit.WinUI.Controls.ColorPicker" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 </Project>

--- a/components/ColorAnalyzer/samples/Dependencies.props
+++ b/components/ColorAnalyzer/samples/Dependencies.props
@@ -12,13 +12,13 @@
     <!-- WinUI 2 -->
     <ItemGroup Condition="'$(WinUIMajorVersion)' == '2'">
         <!-- <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/> -->
-      <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
-      <PackageReference Include="CommunityToolkit.Uwp.Controls.ColorPicker" Version="8.3.260331-pull-837.1767"/>
+      <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
+      <PackageReference Include="CommunityToolkit.Uwp.Controls.ColorPicker" Version="8.3.260402-preview2"/>
     </ItemGroup>
   
     <!-- WinUI 3 -->
     <ItemGroup Condition="'$(WinUIMajorVersion)' == '3'">
-      <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
-      <PackageReference Include="CommunityToolkit.WinUI.Controls.ColorPicker" Version="8.3.260331-pull-837.1767"/>
+      <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
+      <PackageReference Include="CommunityToolkit.WinUI.Controls.ColorPicker" Version="8.3.260402-preview2"/>
     </ItemGroup>
 </Project>

--- a/components/DataTable/samples/Dependencies.props
+++ b/components/DataTable/samples/Dependencies.props
@@ -11,14 +11,14 @@
 <Project>
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 
     <!-- WinUI 2 / UWP -->

--- a/components/DataTable/samples/Dependencies.props
+++ b/components/DataTable/samples/Dependencies.props
@@ -11,14 +11,14 @@
 <Project>
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.HeaderedControls" Version="8.3.260402-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.HeaderedControls" Version="8.3.260402-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 2 / UWP -->

--- a/components/DataTable/src/Dependencies.props
+++ b/components/DataTable/src/Dependencies.props
@@ -14,15 +14,15 @@
   
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 </Project>

--- a/components/DataTable/src/Dependencies.props
+++ b/components/DataTable/src/Dependencies.props
@@ -14,15 +14,15 @@
   
     <!-- WinUI 2 / UWP / Uno -->
     <ItemGroup Condition="'$(IsUwp)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2')">
-        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Controls.Sizers" Version="8.3.260402-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk / Uno -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true' OR ('$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3')">
-        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
-        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260402-preview2"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.3.260402-preview2"/>
     </ItemGroup>
 </Project>

--- a/components/Marquee/samples/Dependencies.props
+++ b/components/Marquee/samples/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
-         <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/> 
+         <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/> 
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
@@ -21,7 +21,7 @@
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-         <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/> 
+         <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/> 
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->

--- a/components/Marquee/samples/Dependencies.props
+++ b/components/Marquee/samples/Dependencies.props
@@ -11,7 +11,7 @@
 <Project>
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
-         <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/> 
+         <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/> 
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
@@ -21,7 +21,7 @@
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-         <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/> 
+         <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/> 
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->

--- a/components/RivePlayer/samples/Dependencies.props
+++ b/components/RivePlayer/samples/Dependencies.props
@@ -12,24 +12,24 @@
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
         <!-- <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
         <!-- <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
         <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.100-dev.15.g12261e2626"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
     </ItemGroup>
 </Project>

--- a/components/RivePlayer/samples/Dependencies.props
+++ b/components/RivePlayer/samples/Dependencies.props
@@ -12,24 +12,24 @@
     <!-- WinUI 2 / UWP -->
     <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 2 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
         <!-- <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11"/> -->
-        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
     </ItemGroup>
 
     <!-- WinUI 3 / WinAppSdk -->
     <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
         <!-- <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
     </ItemGroup>
     
     <!-- WinUI 3 / Uno -->
     <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
         <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.100-dev.15.g12261e2626"/> -->
-        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+        <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
     </ItemGroup>
 </Project>

--- a/components/RivePlayer/src/MultiTarget.props
+++ b/components/RivePlayer/src/MultiTarget.props
@@ -4,6 +4,6 @@
       MultiTarget is a custom property that indicates which target a project is designed to be built for / run on.
       Used to create project references, generate solution files, enable/disable TargetFrameworks, and build nuget packages.
     -->
-      <MultiTarget>uwp;wasdk;wasm;</MultiTarget>
+      <MultiTarget>uwp;wasm;</MultiTarget>
   </PropertyGroup>
 </Project>

--- a/components/Shimmer/src/Dependencies.props
+++ b/components/Shimmer/src/Dependencies.props
@@ -12,24 +12,24 @@
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
     <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.3"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260402-preview2" />
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
     <!--  <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260402-preview2" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
     <!-- <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260402-preview2" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
     <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260402-preview2" />
   </ItemGroup>
 </Project>

--- a/components/Shimmer/src/Dependencies.props
+++ b/components/Shimmer/src/Dependencies.props
@@ -12,24 +12,24 @@
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
     <!-- <PackageReference Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.3"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767" />
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
     <!--  <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11"/> -->
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767" />
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
     <!-- <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767" />
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
     <!-- <PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100"/> -->
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767" />
   </ItemGroup>
 </Project>

--- a/components/TitleBar/tests/ExampleTitleBarTestClass.cs
+++ b/components/TitleBar/tests/ExampleTitleBarTestClass.cs
@@ -5,6 +5,7 @@
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
 using CommunityToolkit.WinUI.Controls;
+using TitleBar = CommunityToolkit.WinUI.Controls.TitleBar;
 
 namespace TitleBarTests;
 

--- a/components/TokenView/src/Dependencies.props
+++ b/components/TokenView/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260402-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/TokenView/src/Dependencies.props
+++ b/components/TokenView/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/samples/Dependencies.props
+++ b/components/TransitionHelper/samples/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/samples/Dependencies.props
+++ b/components/TransitionHelper/samples/Dependencies.props
@@ -11,21 +11,21 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/src/Dependencies.props
+++ b/components/TransitionHelper/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260402-preview2"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260402-preview2"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260402-preview2"/>
   </ItemGroup>
 </Project>

--- a/components/TransitionHelper/src/Dependencies.props
+++ b/components/TransitionHelper/src/Dependencies.props
@@ -11,25 +11,25 @@
 <Project>
   <!-- WinUI 2 / UWP -->
   <ItemGroup Condition="'$(IsUwp)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 2 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '2'">
-    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / WinAppSdk -->
   <ItemGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 
   <!-- WinUI 3 / Uno -->
   <ItemGroup Condition="'$(IsUno)' == 'true' AND '$(WinUIMajorVersion)' == '3'">
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402"/>
-    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.2.250402"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.3.260331-pull-837.1767"/>
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.3.260331-pull-837.1767"/>
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,8 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
+    <add key="PullRequests" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-PullRequests/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
-    <add key="PullRequests" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-PullRequests/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
This PR upgrades our tooling, components, and dependencies to the 1.8 version of the Windows App SDK. 

The changes here have had basic builds/tests run locally, and fixes several of the build issues encountered while trying to build WASDK under the new version. 

Remaining uncertainty:
- The errors in the tooling CI are caused by a package reference to an old version of the toolkit using older versions of WADSK, particularly we noted CommunityToolkit.Common (and will check for more). 

Prerequisites:
- The PR at https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/293 needs to be merged before this PR can be closed. 
- Before we can close this PR, we'll need to use the PR nuget feed here to ship a prerelease update to any toolkit components that are referenced in the gallery by our tooling.
    - This is a recurring requirement any time we update the toolkit's dependencies, it also happened with our upgrade to 1.6. 
    - Generally, this friction is being recorded for possible improvements via proper toolkit-using-toolkit tooling.


