### PR TITLE
Optimize codegen for generated dependency property setters

### DIFF
--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/Constants/WellKnownTypeNames.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/Constants/WellKnownTypeNames.cs
@@ -94,4 +94,15 @@ internal static class WellKnownTypeNames
             ? $"{WindowsUIXamlNamespace}.{nameof(CreateDefaultValueCallback)}"
             : $"{MicrosoftUIXamlNamespace}.{nameof(CreateDefaultValueCallback)}";
     }
+
+    /// <summary>
+    /// Gets the fully qualified type name for the <c>XamlBindingHelper</c> type.
+    /// </summary>
+    /// <param name="useWindowsUIXaml"><inheritdoc cref="XamlNamespace(bool)" path="/param[@name='useWindowsUIXaml']/text()"/></param>
+    public static string XamlBindingHelper(bool useWindowsUIXaml)
+    {
+        return useWindowsUIXaml
+            ? $"{WindowsUIXamlNamespace}.Markup.{nameof(XamlBindingHelper)}"
+            : $"{MicrosoftUIXamlNamespace}.Markup.{nameof(XamlBindingHelper)}";
+    }
 }

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
@@ -449,6 +449,60 @@ partial class DependencyPropertyGenerator
         }
 
         /// <summary>
+        /// Checks whether the user has provided an implementation for the <c>On&lt;PROPERTY_NAME&gt;Set(ref object)</c> partial method.
+        /// </summary>
+        /// <param name="propertySymbol">The input <see cref="IPropertySymbol"/> instance to process.</param>
+        /// <returns>Whether the user has an implementation for the boxed set callback.</returns>
+        public static bool IsObjectSetCallbackImplemented(IPropertySymbol propertySymbol)
+        {
+            // Check for any 'On<PROPERTY_NAME>Set' methods with a single ref 'object' parameter
+            foreach (ISymbol symbol in propertySymbol.ContainingType.GetMembers($"On{propertySymbol.Name}Set"))
+            {
+                if (symbol is IMethodSymbol { IsStatic: false, ReturnsVoid: true, Parameters: [{ RefKind: RefKind.Ref, Type.SpecialType: SpecialType.System_Object }] })
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the <c>XamlBindingHelper.SetPropertyFrom*</c> method name for a given property type, if supported.
+        /// </summary>
+        /// <param name="typeSymbol">The input <see cref="ITypeSymbol"/> to check.</param>
+        /// <returns>The method name to use, or <see langword="null"/> if the type is not supported.</returns>
+        public static string? GetXamlBindingHelperSetMethodName(ITypeSymbol typeSymbol)
+        {
+            // Check for well known primitive types first (these are the most common)
+            switch (typeSymbol.SpecialType)
+            {
+                case SpecialType.System_Boolean: return "SetPropertyFromBoolean";
+                case SpecialType.System_Byte: return "SetPropertyFromByte";
+                case SpecialType.System_Char: return "SetPropertyFromChar16";
+                case SpecialType.System_Double: return "SetPropertyFromDouble";
+                case SpecialType.System_Int32: return "SetPropertyFromInt32";
+                case SpecialType.System_Int64: return "SetPropertyFromInt64";
+                case SpecialType.System_Single: return "SetPropertyFromSingle";
+                case SpecialType.System_String: return "SetPropertyFromString";
+                case SpecialType.System_UInt32: return "SetPropertyFromUInt32";
+                case SpecialType.System_UInt64: return "SetPropertyFromUInt64";
+                case SpecialType.System_Object: return "SetPropertyFromObject";
+                default: break;
+            }
+
+            // Check for the remaining well known WinRT projected types
+            if (typeSymbol.HasFullyQualifiedMetadataName("System.DateTimeOffset")) return "SetPropertyFromDateTime";
+            if (typeSymbol.HasFullyQualifiedMetadataName("System.TimeSpan")) return "SetPropertyFromTimeSpan";
+            if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Point")) return "SetPropertyFromPoint";
+            if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Rect")) return "SetPropertyFromRect";
+            if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Size")) return "SetPropertyFromSize";
+            if (typeSymbol.HasFullyQualifiedMetadataName("System.Uri")) return "SetPropertyFromUri";
+
+            return null;
+        }
+
+        /// <summary>
         /// Gathers all forwarded attributes for the generated property.
         /// </summary>
         ///<param name="node">The input <see cref="PropertyDeclarationSyntax"/> node.</param>
@@ -708,21 +762,39 @@ partial class DependencyPropertyGenerator
                                 On{{propertyInfo.PropertyName}}Changing(__oldValue, value);
 
                                 field = value;
-
-                                object? __boxedValue = value;
                             """, isMultiline: true);
-                        writer.WriteLineIf(propertyInfo.TypeName != "object", $"""
 
-                                On{propertyInfo.PropertyName}Set(ref __boxedValue);
-                            """, isMultiline: true);
-                        writer.Write($$"""
+                        // If an optimized 'XamlBindingHelper' method is available, use it directly
+                        if (propertyInfo.XamlBindingHelperSetMethodName is string setMethodName)
+                        {
+                            writer.Write($$"""
 
-                                SetValue({{propertyInfo.PropertyName}}Property, __boxedValue);
+                                    global::{{WellKnownTypeNames.XamlBindingHelper(propertyInfo.UseWindowsUIXaml)}}.{{setMethodName}}(this, {{propertyInfo.PropertyName}}Property, value);
 
-                                On{{propertyInfo.PropertyName}}Changed(value);
-                                On{{propertyInfo.PropertyName}}Changed(__oldValue, value);
-                            }
-                            """, isMultiline: true);
+                                    On{{propertyInfo.PropertyName}}Changed(value);
+                                    On{{propertyInfo.PropertyName}}Changed(__oldValue, value);
+                                }
+                                """, isMultiline: true);
+                        }
+                        else
+                        {
+                            writer.Write($$"""
+
+                                    object? __boxedValue = value;
+                                """, isMultiline: true);
+                            writer.WriteLineIf(propertyInfo.TypeName != "object", $"""
+
+                                    On{propertyInfo.PropertyName}Set(ref __boxedValue);
+                                """, isMultiline: true);
+                            writer.Write($$"""
+
+                                    SetValue({{propertyInfo.PropertyName}}Property, __boxedValue);
+
+                                    On{{propertyInfo.PropertyName}}Changed(value);
+                                    On{{propertyInfo.PropertyName}}Changed(__oldValue, value);
+                                }
+                                """, isMultiline: true);
+                        }
 
                         // If the default value is not what the default field value would be, add an initializer
                         if (propertyInfo.DefaultValue is not (DependencyPropertyDefaultValue.Null or DependencyPropertyDefaultValue.Default or DependencyPropertyDefaultValue.Callback))
@@ -758,9 +830,34 @@ partial class DependencyPropertyGenerator
                             }
                             """, isMultiline: true);
                     }
-                    else
+                    else  if (propertyInfo.XamlBindingHelperSetMethodName is string setMethodName)
                     {
                         // Same as above but with the extra typed hook for both accessors
+                        writer.WriteLine($$"""
+                            {{GetExpressionWithTrailingSpace(propertyInfo.GetterAccessibility)}}get
+                            {
+                                object? __boxedValue = GetValue({{propertyInfo.PropertyName}}Property);
+
+                                On{{propertyInfo.PropertyName}}Get(ref __boxedValue);
+
+                                {{propertyInfo.TypeNameWithNullabilityAnnotations}} __unboxedValue = ({{propertyInfo.TypeNameWithNullabilityAnnotations}})__boxedValue;
+
+                                On{{propertyInfo.PropertyName}}Get(ref __unboxedValue);
+
+                                return __unboxedValue;
+                            }
+                            {{GetExpressionWithTrailingSpace(propertyInfo.SetterAccessibility)}}set
+                            {
+                                On{{propertyInfo.PropertyName}}Set(ref value);
+
+                                global::{{WellKnownTypeNames.XamlBindingHelper(propertyInfo.UseWindowsUIXaml)}}.{{setMethodName}}(this, {{propertyInfo.PropertyName}}Property, value);
+
+                                On{{propertyInfo.PropertyName}}Changed(value);
+                            }
+                            """, isMultiline: true);
+                    }
+                    else
+                    {
                         writer.WriteLine($$"""
                             {{GetExpressionWithTrailingSpace(propertyInfo.GetterAccessibility)}}get
                             {
@@ -787,7 +884,6 @@ partial class DependencyPropertyGenerator
                                 On{{propertyInfo.PropertyName}}Changed(value);
                             }
                             """, isMultiline: true);
-
                     }
                 }
             }

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.cs
@@ -107,6 +107,26 @@ public sealed partial class DependencyPropertyGenerator : IIncrementalGenerator
 
                     token.ThrowIfCancellationRequested();
 
+                    // Get the optimized XamlBindingHelper method name for the property type, if applicable.
+                    // This is only used when the property type is not 'object' (which would gain nothing),
+                    // and the user hasn't provided their own 'On<PROPERTY_NAME>Set(ref object)' implementation.
+                    string? xamlBindingHelperSetMethodName = Execute.GetXamlBindingHelperSetMethodName(propertySymbol.Type);
+
+                    if (xamlBindingHelperSetMethodName is not null)
+                    {
+                        // Skip the optimization for the 'object' type (it gains nothing)
+                        if (propertySymbol.Type.SpecialType == SpecialType.System_Object)
+                        {
+                            xamlBindingHelperSetMethodName = null;
+                        }
+                        else if (Execute.IsObjectSetCallbackImplemented(propertySymbol))
+                        {
+                            xamlBindingHelperSetMethodName = null;
+                        }
+                    }
+
+                    token.ThrowIfCancellationRequested();
+
                     // We're using IsValueType here and not IsReferenceType to also cover unconstrained type parameter cases.
                     // This will cover both reference types as well T when the constraints are not struct or unmanaged.
                     // If this is true, it means the field storage can potentially be in a null state (even if not annotated).
@@ -160,6 +180,7 @@ public sealed partial class DependencyPropertyGenerator : IIncrementalGenerator
                         IsSharedPropertyChangedCallbackImplemented: isSharedPropertyChangedCallbackImplemented,
                         IsAdditionalTypesGenerationSupported: isAdditionalTypesGenerationSupported,
                         UseWindowsUIXaml: useWindowsUIXaml,
+                        XamlBindingHelperSetMethodName: xamlBindingHelperSetMethodName,
                         StaticFieldAttributes: staticFieldAttributes);
                 })
             .WithTrackingName(WellKnownTrackingNames.Execute)

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/Models/DependencyPropertyInfo.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/Models/DependencyPropertyInfo.cs
@@ -26,6 +26,7 @@ namespace CommunityToolkit.GeneratedDependencyProperty.Models;
 /// <param name="IsSharedPropertyChangedCallbackImplemented">Indicates whether the WinRT-based shared property changed callback is implemented.</param>
 /// <param name="IsAdditionalTypesGenerationSupported">Indicates whether additional types can be generated.</param>
 /// <param name="UseWindowsUIXaml">Whether to use the UWP XAML or WinUI 3 XAML namespaces.</param>
+/// <param name="XamlBindingHelperSetMethodName">The name of the <c>XamlBindingHelper.SetPropertyFrom*</c> method to use for optimized setters, if available.</param>
 /// <param name="StaticFieldAttributes">The attributes to emit on the generated static field, if any.</param>
 internal sealed record DependencyPropertyInfo(
     HierarchyInfo Hierarchy,
@@ -44,4 +45,5 @@ internal sealed record DependencyPropertyInfo(
     bool IsSharedPropertyChangedCallbackImplemented,
     bool IsAdditionalTypesGenerationSupported,
     bool UseWindowsUIXaml,
+    string? XamlBindingHelperSetMethodName,
     EquatableArray<AttributeInfo> StaticFieldAttributes);

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpAnalyzerTest{TAnalyzer}.cs
@@ -39,6 +39,11 @@ internal sealed class CSharpAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyz
     private CSharpAnalyzerTest(LanguageVersion languageVersion)
     {
         this.languageVersion = languageVersion;
+
+        TestState.AnalyzerConfigFiles.Add(("/.globalconfig", """
+            is_global = true
+            build_property.DependencyPropertyGeneratorUseWindowsUIXaml = true
+            """));
     }
 
     /// <inheritdoc/>

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpCodeFixerTest{TAnalyzer,TCodeFixer}.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpCodeFixerTest{TAnalyzer,TCodeFixer}.cs
@@ -43,6 +43,10 @@ internal sealed class CSharpCodeFixTest<TAnalyzer, TCodeFixer> : CSharpCodeFixTe
         TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(DependencyProperty).Assembly.Location));
         TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(GeneratedDependencyPropertyAttribute).Assembly.Location));
         TestState.AnalyzerConfigFiles.Add(("/.editorconfig", "[*]\nend_of_line = lf"));
+        TestState.AnalyzerConfigFiles.Add(("/.globalconfig", """
+            is_global = true
+            build_property.DependencyPropertyGeneratorUseWindowsUIXaml = true
+            """));
     }
 
     /// <inheritdoc/>

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpGeneratorTest{TGenerator}.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpGeneratorTest{TGenerator}.cs
@@ -91,6 +91,7 @@ internal static class CSharpGeneratorTest<TGenerator>
 
         GeneratorDriver driver = CSharpGeneratorDriver.Create(
             generators: [new TGenerator().AsSourceGenerator()],
+            optionsProvider: DependencyPropertyGeneratorAnalyzerConfigOptionsProvider.Instance,
             driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
 
         // Run the generator on the initial sources
@@ -166,7 +167,9 @@ internal static class CSharpGeneratorTest<TGenerator>
         Compilation originalCompilation = CreateCompilation(source, languageVersion);
 
         // Create the generator driver with the specified generator
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(new TGenerator()).WithUpdatedParseOptions(originalCompilation.SyntaxTrees.First().Options);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new TGenerator().AsSourceGenerator()],
+            optionsProvider: DependencyPropertyGeneratorAnalyzerConfigOptionsProvider.Instance).WithUpdatedParseOptions(originalCompilation.SyntaxTrees.First().Options);
 
         // Run all source generators on the input source code
         _ = driver.RunGeneratorsAndUpdateCompilation(originalCompilation, out compilation, out diagnostics);

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpSuppressorTest{TSuppressor}.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/CSharpSuppressorTest{TSuppressor}.cs
@@ -63,6 +63,10 @@ public sealed class CSharpSuppressorTest<TSuppressor> : CSharpAnalyzerTest<TSupp
         TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(ApplicationView).Assembly.Location));
         TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(DependencyProperty).Assembly.Location));
         TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(GeneratedDependencyPropertyAttribute).Assembly.Location));
+        TestState.AnalyzerConfigFiles.Add(("/.globalconfig", """
+            is_global = true
+            build_property.DependencyPropertyGeneratorUseWindowsUIXaml = true
+            """));
     }
 
     /// <inheritdoc/>

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/DependencyPropertyGeneratorAnalyzerConfigOptionsProvider.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Helpers/DependencyPropertyGeneratorAnalyzerConfigOptionsProvider.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace CommunityToolkit.GeneratedDependencyProperty.Tests.Helpers;
+
+/// <summary>
+/// A custom <see cref="AnalyzerConfigOptionsProvider"/> providing the MSBuild properties needed by the dependency property generator.
+/// </summary>
+internal sealed class DependencyPropertyGeneratorAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+{
+    /// <summary>
+    /// The singleton <see cref="DependencyPropertyGeneratorAnalyzerConfigOptionsProvider"/> instance.
+    /// </summary>
+    public static DependencyPropertyGeneratorAnalyzerConfigOptionsProvider Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GlobalOptions { get; } = new SimpleAnalyzerConfigOptions(
+        ImmutableDictionary<string, string>.Empty.Add("build_property.DependencyPropertyGeneratorUseWindowsUIXaml", "true"));
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
+    {
+        return SimpleAnalyzerConfigOptions.Empty;
+    }
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
+    {
+        return SimpleAnalyzerConfigOptions.Empty;
+    }
+
+    /// <summary>
+    /// A simple <see cref="AnalyzerConfigOptions"/> implementation backed by an immutable dictionary.
+    /// </summary>
+    /// <param name="options">The dictionary of options.</param>
+    private sealed class SimpleAnalyzerConfigOptions(ImmutableDictionary<string, string> options) : AnalyzerConfigOptions
+    {
+        /// <summary>
+        /// An empty <see cref="SimpleAnalyzerConfigOptions"/> instance.
+        /// </summary>
+        public static SimpleAnalyzerConfigOptions Empty { get; } = new(ImmutableDictionary<string, string>.Empty);
+
+        /// <inheritdoc/>
+        public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+        {
+            return options.TryGetValue(key, out value);
+        }
+    }
+}

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
@@ -70,11 +70,7 @@ public partial class Test_DependencyPropertyGenerator
 
                             field = value;
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                             OnNumberChanged(__oldValue, value);
@@ -202,11 +198,7 @@ public partial class Test_DependencyPropertyGenerator
 
                             field = value;
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                             OnNumberChanged(__oldValue, value);
@@ -376,11 +368,7 @@ public partial class Test_DependencyPropertyGenerator
 
                             field = value;
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                             OnNumberChanged(__oldValue, value);
@@ -501,11 +489,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -617,11 +601,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -739,11 +719,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -903,11 +879,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -1166,11 +1138,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -1336,11 +1304,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -1510,11 +1474,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -1680,11 +1640,7 @@ public partial class Test_DependencyPropertyGenerator
 
                             field = value;
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                             OnNameChanged(__oldValue, value);
@@ -1805,11 +1761,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -1921,11 +1873,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -2042,11 +1990,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -2158,11 +2102,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -2281,11 +2221,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -2397,11 +2333,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -2526,11 +2458,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnFirstNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnFirstNameSet(ref __boxedValue);
-
-                            SetValue(FirstNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, FirstNameProperty, value);
 
                             OnFirstNameChanged(value);
                         }
@@ -2558,11 +2486,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnLastNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnLastNameSet(ref __boxedValue);
-
-                            SetValue(LastNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, LastNameProperty, value);
 
                             OnLastNameChanged(value);
                         }
@@ -2729,11 +2653,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnFirstNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnFirstNameSet(ref __boxedValue);
-
-                            SetValue(FirstNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, FirstNameProperty, value);
 
                             OnFirstNameChanged(value);
                         }
@@ -2761,11 +2681,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnLastNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnLastNameSet(ref __boxedValue);
-
-                            SetValue(LastNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, LastNameProperty, value);
 
                             OnLastNameChanged(value);
                         }
@@ -2982,11 +2898,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnFirstNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnFirstNameSet(ref __boxedValue);
-
-                            SetValue(FirstNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, FirstNameProperty, value);
 
                             OnFirstNameChanged(value);
                         }
@@ -3014,11 +2926,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnLastNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnLastNameSet(ref __boxedValue);
-
-                            SetValue(LastNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, LastNameProperty, value);
 
                             OnLastNameChanged(value);
                         }
@@ -3251,11 +3159,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnFirstNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnFirstNameSet(ref __boxedValue);
-
-                            SetValue(FirstNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, FirstNameProperty, value);
 
                             OnFirstNameChanged(value);
                         }
@@ -3283,11 +3187,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnLastNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnLastNameSet(ref __boxedValue);
-
-                            SetValue(LastNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, LastNameProperty, value);
 
                             OnLastNameChanged(value);
                         }
@@ -3534,11 +3434,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnFirstNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnFirstNameSet(ref __boxedValue);
-
-                            SetValue(FirstNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, FirstNameProperty, value);
 
                             OnFirstNameChanged(value);
                         }
@@ -3566,11 +3462,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnLastNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnLastNameSet(ref __boxedValue);
-
-                            SetValue(LastNameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, LastNameProperty, value);
 
                             OnLastNameChanged(value);
                         }
@@ -3799,11 +3691,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromInt32(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -4047,11 +3935,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -4108,21 +3992,21 @@ public partial class Test_DependencyPropertyGenerator
     [TestMethod]
 
     // The 'string' type is special
-    [DataRow("string", "string", "object", "null")]
-    [DataRow("string", "string?", "object?", "null")]
+    [DataRow("string", "string", "object", "null", "", "SetPropertyFromString")]
+    [DataRow("string", "string?", "object?", "null", "", "SetPropertyFromString")]
 
     // Well known WinRT primitive types
-    [DataRow("int", "int", "object", "null")]
-    [DataRow("byte", "byte", "object", "null")]
+    [DataRow("int", "int", "object", "null", "", "SetPropertyFromInt32")]
+    [DataRow("byte", "byte", "object", "null", "", "SetPropertyFromByte")]
     [DataRow("sbyte", "sbyte", "object", "null")]
     [DataRow("short", "short", "object", "null")]
     [DataRow("ushort", "ushort", "object", "null")]
-    [DataRow("uint", "uint", "object", "null")]
-    [DataRow("long", "long", "object", "null")]
-    [DataRow("ulong", "ulong", "object", "null")]
-    [DataRow("char", "char", "object", "null")]
-    [DataRow("float", "float", "object", "null")]
-    [DataRow("double", "double", "object", "null")]
+    [DataRow("uint", "uint", "object", "null", "", "SetPropertyFromUInt32")]
+    [DataRow("long", "long", "object", "null", "", "SetPropertyFromInt64")]
+    [DataRow("ulong", "ulong", "object", "null", "", "SetPropertyFromUInt64")]
+    [DataRow("char", "char", "object", "null", "", "SetPropertyFromChar16")]
+    [DataRow("float", "float", "object", "null", "", "SetPropertyFromSingle")]
+    [DataRow("double", "double", "object", "null", "", "SetPropertyFromDouble")]
 
     // Well known WinRT struct types
     [DataRow("global::System.Numerics.Matrix3x2", "global::System.Numerics.Matrix3x2", "object", "null")]
@@ -4132,11 +4016,11 @@ public partial class Test_DependencyPropertyGenerator
     [DataRow("global::System.Numerics.Vector2", "global::System.Numerics.Vector2", "object", "null")]
     [DataRow("global::System.Numerics.Vector3", "global::System.Numerics.Vector3", "object", "null")]
     [DataRow("global::System.Numerics.Vector4", "global::System.Numerics.Vector4", "object", "null")]
-    [DataRow("global::Windows.Foundation.Point", "global::Windows.Foundation.Point", "object", "null")]
-    [DataRow("global::Windows.Foundation.Rect", "global::Windows.Foundation.Rect", "object", "null")]
-    [DataRow("global::Windows.Foundation.Size", "global::Windows.Foundation.Size", "object", "null")]
-    [DataRow("global::System.TimeSpan", "global::System.TimeSpan", "object", "null")]
-    [DataRow("global::System.DateTimeOffset", "global::System.DateTimeOffset", "object", "null")]
+    [DataRow("global::Windows.Foundation.Point", "global::Windows.Foundation.Point", "object", "null", "", "SetPropertyFromPoint")]
+    [DataRow("global::Windows.Foundation.Rect", "global::Windows.Foundation.Rect", "object", "null", "", "SetPropertyFromRect")]
+    [DataRow("global::Windows.Foundation.Size", "global::Windows.Foundation.Size", "object", "null", "", "SetPropertyFromSize")]
+    [DataRow("global::System.TimeSpan", "global::System.TimeSpan", "object", "null", "", "SetPropertyFromTimeSpan")]
+    [DataRow("global::System.DateTimeOffset", "global::System.DateTimeOffset", "object", "null", "", "SetPropertyFromDateTime")]
 
     // Well known WinRT enum types
     [DataRow("global::Windows.UI.Xaml.Visibility", "global::Windows.UI.Xaml.Visibility", "object", "null")]
@@ -4164,8 +4048,20 @@ public partial class Test_DependencyPropertyGenerator
         string propertyType,
         string defaultValueDefinition,
         string propertyMetadataExpression,
-        string? typeDefinition = "")
+        string? typeDefinition = "",
+        string? setMethodName = null)
     {
+        // Compute the setter body and partial method block based on whether the optimization is used
+        string setterBody = setMethodName is not null
+            ? $"global::Windows.UI.Xaml.Markup.XamlBindingHelper.{setMethodName}(this, NameProperty, value)"
+            : $$"""
+                             object? __boxedValue = value;
+
+                             OnNameSet(ref __boxedValue);
+
+                             SetValue(NameProperty, __boxedValue)
+             """;
+
         string source = $$"""
             using System;
             using System.Collections.Generic;
@@ -4229,11 +4125,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            {{setterBody}};
 
                             OnNameChanged(value);
                         }
@@ -4375,11 +4267,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -4491,11 +4379,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnIsSelectedSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnIsSelectedSet(ref __boxedValue);
-
-                            SetValue(IsSelectedProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromBoolean(this, IsSelectedProperty, value);
 
                             OnIsSelectedChanged(value);
                         }
@@ -4550,16 +4434,16 @@ public partial class Test_DependencyPropertyGenerator
     }
 
     [TestMethod]
-    [DataRow("bool", "bool", "null", "bool", "object", "null")]
-    [DataRow("bool", "bool", "bool", "bool", "object", "null")]
-    [DataRow("bool", "bool", "object", "object", "object", "new global::Windows.UI.Xaml.PropertyMetadata(default(bool))")]
+    [DataRow("bool", "bool", "null", "bool", "object", "null", "SetPropertyFromBoolean")]
+    [DataRow("bool", "bool", "bool", "bool", "object", "null", "SetPropertyFromBoolean")]
+    [DataRow("bool", "bool", "object", "object", "object", "new global::Windows.UI.Xaml.PropertyMetadata(default(bool))", "SetPropertyFromBoolean")]
     [DataRow("bool?", "bool?", "null", "bool?", "object?", "null")]
     [DataRow("bool?", "bool?", "bool?", "bool?", "object?", "null")]
     [DataRow("bool?", "bool?", "object", "object", "object?", "null")]
     [DataRow("bool?", "bool?", "bool", "bool", "object?", "new global::Windows.UI.Xaml.PropertyMetadata(null)")]
-    [DataRow("string?", "string?", "null", "string", "object?", "null")]
-    [DataRow("string?", "string?", "string", "string", "object?", "null")]
-    [DataRow("string?", "string?", "object", "object", "object?", "null")]
+    [DataRow("string?", "string?", "null", "string", "object?", "null", "SetPropertyFromString")]
+    [DataRow("string?", "string?", "string", "string", "object?", "null", "SetPropertyFromString")]
+    [DataRow("string?", "string?", "object", "object", "object?", "null", "SetPropertyFromString")]
     [DataRow("Visibility", "global::Windows.UI.Xaml.Visibility", "object", "object", "object", "new global::Windows.UI.Xaml.PropertyMetadata(default(global::Windows.UI.Xaml.Visibility))")]
     [DataRow("Visibility?", "global::Windows.UI.Xaml.Visibility?", "object", "object", "object?", "null")]
     public void SingleProperty_WithCustomMetadataType_WithNoCaching(
@@ -4568,8 +4452,20 @@ public partial class Test_DependencyPropertyGenerator
         string propertyType,
         string generatedPropertyType,
         string boxedType,
-        string propertyMetadata)
+        string propertyMetadata,
+        string? setMethodName = null)
     {
+        // Compute the setter body and partial method block based on whether the optimization is used
+        string setterBody = setMethodName is not null
+            ? $"global::Windows.UI.Xaml.Markup.XamlBindingHelper.{setMethodName}(this, IsSelectedProperty, value)"
+            : $$"""
+                             object? __boxedValue = value;
+
+                             OnIsSelectedSet(ref __boxedValue);
+
+                             SetValue(IsSelectedProperty, __boxedValue)
+             """;
+
         string source = $$"""
             using CommunityToolkit.WinUI;
             using Windows.UI.Xaml;
@@ -4627,11 +4523,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnIsSelectedSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnIsSelectedSet(ref __boxedValue);
-
-                            SetValue(IsSelectedProperty, __boxedValue);
+                            {{setterBody}};
 
                             OnIsSelectedChanged(value);
                         }
@@ -4895,11 +4787,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -5022,11 +4910,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -5149,11 +5033,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -5286,11 +5166,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNumberSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNumberSet(ref __boxedValue);
-
-                            SetValue(NumberProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NumberProperty, value);
 
                             OnNumberChanged(value);
                         }
@@ -5949,5 +5825,125 @@ public partial class Test_DependencyPropertyGenerator
             """;
 
         CSharpGeneratorTest<DependencyPropertyGenerator>.VerifySources(source, ("MyNamespace.MyObject`4.g.cs", result), languageVersion: LanguageVersion.Preview);
+    }
+
+    [TestMethod]
+    public void SingleProperty_Int32_WithNoCaching_WithObjectSetCallback()
+    {
+        const string source = """
+            using CommunityToolkit.WinUI;
+            using Windows.UI.Xaml;
+
+            namespace MyNamespace;
+
+            public partial class MyControl : DependencyObject
+            {
+                [GeneratedDependencyProperty]
+                public partial int Number { get; set; }
+
+                partial void OnNumberSet(ref object propertyValue)
+                {
+                }
+            }
+            """;
+
+        const string result = """
+            // <auto-generated/>
+            #pragma warning disable
+            #nullable enable
+
+            namespace MyNamespace
+            {
+                /// <inheritdoc cref="MyControl"/>
+                partial class MyControl
+                {
+                    /// <summary>
+                    /// The backing <see cref="global::Windows.UI.Xaml.DependencyProperty"/> instance for <see cref="Number"/>.
+                    /// </summary>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    public static readonly global::Windows.UI.Xaml.DependencyProperty NumberProperty = global::Windows.UI.Xaml.DependencyProperty.Register(
+                        name: "Number",
+                        propertyType: typeof(int),
+                        ownerType: typeof(MyControl),
+                        typeMetadata: null);
+
+                    /// <inheritdoc/>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    [global::System.Diagnostics.DebuggerNonUserCode]
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    public partial int Number
+                    {
+                        get
+                        {
+                            object? __boxedValue = GetValue(NumberProperty);
+
+                            OnNumberGet(ref __boxedValue);
+
+                            int __unboxedValue = (int)__boxedValue;
+
+                            OnNumberGet(ref __unboxedValue);
+
+                            return __unboxedValue;
+                        }
+                        set
+                        {
+                            OnNumberSet(ref value);
+
+                            object? __boxedValue = value;
+
+                            OnNumberSet(ref __boxedValue);
+
+                            SetValue(NumberProperty, __boxedValue);
+
+                            OnNumberChanged(value);
+                        }
+                    }
+
+                    /// <summary>Executes the logic for when the <see langword="get"/> accessor <see cref="Number"/> is invoked</summary>
+                    /// <param name="propertyValue">The raw property value that has been retrieved from <see cref="NumberProperty"/>.</param>
+                    /// <remarks>This method is invoked on the boxed value retrieved via <see cref="GetValue"/> on <see cref="NumberProperty"/>.</remarks>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    partial void OnNumberGet(ref object propertyValue);
+
+                    /// <summary>Executes the logic for when the <see langword="get"/> accessor <see cref="Number"/> is invoked</summary>
+                    /// <param name="propertyValue">The unboxed property value that has been retrieved from <see cref="NumberProperty"/>.</param>
+                    /// <remarks>This method is invoked on the unboxed value retrieved via <see cref="GetValue"/> on <see cref="NumberProperty"/>.</remarks>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    partial void OnNumberGet(ref int propertyValue);
+
+                    /// <summary>Executes the logic for when the <see langword="set"/> accessor <see cref="Number"/> is invoked</summary>
+                    /// <param name="propertyValue">The boxed property value that has been produced before assigning to <see cref="NumberProperty"/>.</param>
+                    /// <remarks>This method is invoked on the boxed value that is about to be passed to <see cref="SetValue"/> on <see cref="NumberProperty"/>.</remarks>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    partial void OnNumberSet(ref object propertyValue);
+
+                    /// <summary>Executes the logic for when the <see langword="set"/> accessor <see cref="Number"/> is invoked</summary>
+                    /// <param name="propertyValue">The property value that is being assigned to <see cref="Number"/>.</param>
+                    /// <remarks>This method is invoked on the raw value being assigned to <see cref="Number"/>, before <see cref="SetValue"/> is used.</remarks>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    partial void OnNumberSet(ref int propertyValue);
+
+                    /// <summary>Executes the logic for when <see cref="Number"/> has just changed.</summary>
+                    /// <param name="value">The new property value that has been set.</param>
+                    /// <remarks>This method is invoked right after the value of <see cref="Number"/> is changed.</remarks>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    partial void OnNumberChanged(int newValue);
+
+                    /// <summary>Executes the logic for when <see cref="Number"/> has just changed.</summary>
+                    /// <param name="e">Event data that is issued by any event that tracks changes to the effective value of this property.</param>
+                    /// <remarks>This method is invoked by the <see cref="global::Windows.UI.Xaml.DependencyProperty"/> infrastructure, after the value of <see cref="Number"/> is changed.</remarks>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    partial void OnNumberPropertyChanged(global::Windows.UI.Xaml.DependencyPropertyChangedEventArgs e);
+
+                    /// <summary>Executes the logic for when any dependency property has just changed.</summary>
+                    /// <param name="e">Event data that is issued by any event that tracks changes to the effective value of this property.</param>
+                    /// <remarks>This method is invoked by the <see cref="global::Windows.UI.Xaml.DependencyProperty"/> infrastructure, after the value of any dependency property has just changed.</remarks>
+                    [global::System.CodeDom.Compiler.GeneratedCode("CommunityToolkit.WinUI.DependencyPropertyGenerator", <ASSEMBLY_VERSION>)]
+                    partial void OnPropertyChanged(global::Windows.UI.Xaml.DependencyPropertyChangedEventArgs e);
+                }
+            }
+            """;
+
+        CSharpGeneratorTest<DependencyPropertyGenerator>.VerifySources(source, ("MyNamespace.MyControl.g.cs", result), languageVersion: LanguageVersion.Preview);
     }
 }

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
@@ -4050,8 +4050,10 @@ public partial class Test_DependencyPropertyGenerator
     {
         // Compute the setter body and partial method block based on whether the optimization is used
         string setterBody = setMethodName is not null
-            ? $"global::Windows.UI.Xaml.Markup.XamlBindingHelper.{setMethodName}(this, NameProperty, value)"
-            : $$"""
+            ? $"""
+                             global::Windows.UI.Xaml.Markup.XamlBindingHelper.{setMethodName}(this, NameProperty, value)
+             """            
+            : """
                              object? __boxedValue = value;
 
                              OnNameSet(ref __boxedValue);
@@ -4122,7 +4124,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            {{setterBody}};
+            {{setterBody}};
 
                             OnNameChanged(value);
                         }
@@ -4454,8 +4456,10 @@ public partial class Test_DependencyPropertyGenerator
     {
         // Compute the setter body and partial method block based on whether the optimization is used
         string setterBody = setMethodName is not null
-            ? $"global::Windows.UI.Xaml.Markup.XamlBindingHelper.{setMethodName}(this, IsSelectedProperty, value)"
-            : $$"""
+            ? $"""
+                             global::Windows.UI.Xaml.Markup.XamlBindingHelper.{setMethodName}(this, IsSelectedProperty, value)
+             """
+            : """
                              object? __boxedValue = value;
 
                              OnIsSelectedSet(ref __boxedValue);
@@ -4520,7 +4524,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnIsSelectedSet(ref value);
 
-                            {{setterBody}};
+            {{setterBody}};
 
                             OnIsSelectedChanged(value);
                         }

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
@@ -1017,11 +1017,7 @@ public partial class Test_DependencyPropertyGenerator
                         {
                             OnNameSet(ref value);
 
-                            object? __boxedValue = value;
-
-                            OnNameSet(ref __boxedValue);
-
-                            SetValue(NameProperty, __boxedValue);
+                            global::Windows.UI.Xaml.Markup.XamlBindingHelper.SetPropertyFromString(this, NameProperty, value);
 
                             OnNameChanged(value);
                         }
@@ -1076,6 +1072,7 @@ public partial class Test_DependencyPropertyGenerator
     }
 
     [TestMethod]
+    public void SingleProperty_Int32_WithNoCaching_WithDefaultValue_WithCallback()
     {
         const string source = """
             using CommunityToolkit.WinUI;

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.Tests/Test_DependencyPropertyGenerator.cs
@@ -958,7 +958,7 @@ public partial class Test_DependencyPropertyGenerator
     [DataRow("@\"She said \"\"hi\"\"\"", "\"She said \\\"hi\\\"\"")]
     [DataRow("@\"Line1\nLine2\"", "\"Line1\\nLine2\"")]
     [DataRow("@\"Tab\there\"", "\"Tab\\there\"")]
-    [DataRow("@\"C:\\"", "\"C:\\\"")]
+    [DataRow("@\"C:\\\"", "\"C:\\\\\"")]
     [DataRow("@\"C:\\Program Files\\App\"", "\"C:\\\\Program Files\\\\App\"")]
     public void SingleProperty_String_WithNoCaching_WithDefaultValue(string inputLiteral, string expectedLiteral)
     {


### PR DESCRIPTION
This pull request introduces an optimization to the DependencyPropertyGenerator by leveraging specialized `XamlBindingHelper.SetPropertyFrom*` methods for supported property types. This results in more efficient generated code for property setters, while maintaining compatibility with user-defined callbacks and fallback logic for unsupported types. The changes also refactor and extend the generator’s internal APIs to support this feature.

**Optimized setter generation using XamlBindingHelper:**

- The generator now detects if a property type supports a specialized `XamlBindingHelper.SetPropertyFrom*` method (e.g., `SetPropertyFromBoolean`, `SetPropertyFromInt32`). If so, it emits a direct call to this method in the generated setter for improved performance. This optimization is skipped if the property type is `object` or if the user has implemented a custom `On<PropertyName>Set(ref object)` callback. [[1]](diffhunk://#diff-84a6d7b90ab189c1fdfd8103c3a62a726f39e34d0354100578e374e48cedadd1R110-R129) [[2]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7R451-R504) [[3]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7R765-R781) [[4]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7L761-R860)

**API and model extensions to support the optimization:**

- Added a new `XamlBindingHelperSetMethodName` property to the `DependencyPropertyInfo` record, and updated the generator pipeline to compute and pass this value. This enables the code generation logic to conditionally emit the optimized setter code. [[1]](diffhunk://#diff-3c805f06082565f4f4ead64fc1447ea80be60127bc7bd91d26b917140ef5425eR29) [[2]](diffhunk://#diff-3c805f06082565f4f4ead64fc1447ea80be60127bc7bd91d26b917140ef5425eR48) [[3]](diffhunk://#diff-84a6d7b90ab189c1fdfd8103c3a62a726f39e34d0354100578e374e48cedadd1R183)

**Well-known type name utilities:**

- Introduced a utility method `XamlBindingHelper(bool useWindowsUIXaml)` in `WellKnownTypeNames.cs` to resolve the fully qualified type name for `XamlBindingHelper`, supporting both Windows and Microsoft UI XAML namespaces.

**Code generation logic updates:**

- Modified the setter and partial method generation logic to use the optimized path when available, and to only emit the boxed `On<PropertyName>Set(ref object)` partial method when the optimization is not used. [[1]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7R765-R781) [[2]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7R797) [[3]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7L761-R860) [[4]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7L827-R925) [[5]](diffhunk://#diff-b743d577555e45ddc0d42a008c6d0c1e59ebdb2ea132d7d6fb4851145ccec7f7R934)

These changes improve the efficiency of generated dependency property code and maintain backward compatibility for advanced scenarios.