### PR TITLE
Update slngen dependency

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "12.0.13",
+      "version": "12.0.32",
       "commands": [
         "slngen"
       ]


### PR DESCRIPTION
## What
The `GenerateAllSolution.bat` script is failing on ARM64 devices with the error described in microsoft/slngen#676. 
The `slngen` tool has been fixed, but the project is still pulling an old build of the tool.

We can manually update the tools using `dotnet tool update --all`, but it will be simpler to directly pull a fixed build 😊.

## How
I'm updating the requested version of the `slngen` tool to the latest one available: 12.0.32.