### PR TITLE
Add horizontal scrolling to `DataTable`

### DIFF
--- a/components/DataTable/samples/DataTableVirtualizationSample.xaml
+++ b/components/DataTable/samples/DataTableVirtualizationSample.xaml
@@ -13,6 +13,8 @@
     <!--  We need to set height here to enable virtualization due to the SampleRenderer setup  -->
     <ListView Height="300"
               VerticalAlignment="Top"
+              ScrollViewer.HorizontalScrollMode="Enabled"
+              ScrollViewer.HorizontalScrollBarVisibility="Auto"
               ItemsSource="{x:Bind InventoryItems}">
         <ListView.Header>
             <Border Padding="8,4,0,4"
@@ -21,11 +23,14 @@
                 <interactivity:Interaction.Behaviors>
                     <behaviors:StickyHeaderBehavior />
                 </interactivity:Interaction.Behaviors>
-                <controls:DataTable ColumnSpacing="16">
+                <controls:DataTable ColumnSpacing="16"
+                    ScrollViewer.HorizontalScrollMode="Enabled"
+                    ScrollViewer.HorizontalScrollBarVisibility="Auto">
                     <controls:DataColumn Content="Id" />
                     <controls:DataColumn CanResize="True"
+                                         MinWidth="120"
                                          Content="Name" />
-                    <controls:DataColumn CanResize="True">
+                    <controls:DataColumn CanResize="True" MinWidth="120">
                         <TextBlock FontWeight="SemiBold"
                                    Text="Description" />
                     </controls:DataColumn>

--- a/components/DataTable/samples/DataTableVirtualizationSample.xaml
+++ b/components/DataTable/samples/DataTableVirtualizationSample.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="DataTableExperiment.Samples.DataTableVirtualizationSample"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -13,9 +13,9 @@
     <!--  We need to set height here to enable virtualization due to the SampleRenderer setup  -->
     <ListView Height="300"
               VerticalAlignment="Top"
-              ScrollViewer.HorizontalScrollMode="Enabled"
+              ItemsSource="{x:Bind InventoryItems}"
               ScrollViewer.HorizontalScrollBarVisibility="Auto"
-              ItemsSource="{x:Bind InventoryItems}">
+              ScrollViewer.HorizontalScrollMode="Enabled">
         <ListView.Header>
             <Border Padding="8,4,0,4"
                     Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}"
@@ -24,17 +24,20 @@
                     <behaviors:StickyHeaderBehavior />
                 </interactivity:Interaction.Behaviors>
                 <controls:DataTable ColumnSpacing="16"
-                    ScrollViewer.HorizontalScrollMode="Enabled"
-                    ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                                    ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                    ScrollViewer.HorizontalScrollMode="Enabled">
                     <controls:DataColumn Content="Id" />
-                    <controls:DataColumn CanResize="True"
-                                         MinWidth="120"
+                    <controls:DataColumn MinWidth="120"
+                                         CanResize="True"
                                          Content="Name" />
-                    <controls:DataColumn CanResize="True" MinWidth="120">
+                    <controls:DataColumn MinWidth="120"
+                                         CanResize="True">
                         <TextBlock FontWeight="SemiBold"
                                    Text="Description" />
                     </controls:DataColumn>
-                    <controls:DataColumn Content="Quantity"  CanResize="True" MinWidth="120"/>
+                    <controls:DataColumn MinWidth="120"
+                                         CanResize="True"
+                                         Content="Quantity" />
                 </controls:DataTable>
             </Border>
         </ListView.Header>

--- a/components/DataTable/samples/DataTableVirtualizationSample.xaml
+++ b/components/DataTable/samples/DataTableVirtualizationSample.xaml
@@ -34,7 +34,7 @@
                         <TextBlock FontWeight="SemiBold"
                                    Text="Description" />
                     </controls:DataColumn>
-                    <controls:DataColumn Content="Quantity" />
+                    <controls:DataColumn Content="Quantity"  CanResize="True" MinWidth="120"/>
                 </controls:DataTable>
             </Border>
         </ListView.Header>

--- a/components/DataTable/src/DataTable/DataRow.cs
+++ b/components/DataTable/src/DataTable/DataRow.cs
@@ -171,7 +171,7 @@ public partial class DataRow : Panel
             // TODO: What do we want to do if there's unequal children in the DataTable vs. DataRow?
         }
 
-        // Use the calculated desired width from the parent table if available
+        // Use the calculated desired width from the parent table if available, fallback to return our parent's size as the desired size
         double desiredWidth = _parentTable?.CalculateDesiredWidth() ?? _parentPanel?.DesiredSize.Width ?? availableSize.Width;
         return new Size(desiredWidth, maxHeight);
     }

--- a/components/DataTable/src/DataTable/DataRow.cs
+++ b/components/DataTable/src/DataTable/DataRow.cs
@@ -171,8 +171,9 @@ public partial class DataRow : Panel
             // TODO: What do we want to do if there's unequal children in the DataTable vs. DataRow?
         }
 
-        // Otherwise, return our parent's size as the desired size.
-        return new(_parentPanel?.DesiredSize.Width ?? availableSize.Width, maxHeight);
+        // Use the calculated desired width from the parent table if available
+        double desiredWidth = _parentTable?.CalculateDesiredWidth() ?? _parentPanel?.DesiredSize.Width ?? availableSize.Width;
+        return new Size(desiredWidth, maxHeight);
     }
 
     /// <inheritdoc/>

--- a/components/DataTable/src/DataTable/DataTable.cs
+++ b/components/DataTable/src/DataTable/DataTable.cs
@@ -23,12 +23,16 @@ public partial class DataTable : Panel
         double totalWidth = 0;
         var elements = Children.Where(static e => e.Visibility == Visibility.Visible && e is DataColumn);
         
-        foreach (DataColumn column in elements)
+        foreach (DataColumn column in elements.Cast<DataColumn>())
         {
             if (column.CurrentWidth.IsAbsolute)
+            {
                 totalWidth += column.CurrentWidth.Value;
+            }
             else
+            {
                 totalWidth += Math.Max(column.DesiredSize.Width, column.MaxChildDesiredWidth);
+            }
         }
 
         totalWidth += Math.Max(0, elements.Count() - 1) * ColumnSpacing;

--- a/components/DataTable/src/DataTable/DataTable.cs
+++ b/components/DataTable/src/DataTable/DataTable.cs
@@ -18,12 +18,31 @@ public partial class DataTable : Panel
     // TODO: Check with Sergio if there's a better structure here, as I don't need a Dictionary like ConditionalWeakTable
     internal HashSet<DataRow> Rows { get; private set; } = new();
 
+    internal double CalculateDesiredWidth()
+    {
+        double totalWidth = 0;
+        var elements = Children.Where(static e => e.Visibility == Visibility.Visible && e is DataColumn);
+        
+        foreach (DataColumn column in elements)
+        {
+            if (column.CurrentWidth.IsAbsolute)
+                totalWidth += column.CurrentWidth.Value;
+            else
+                totalWidth += Math.Max(column.DesiredSize.Width, column.MaxChildDesiredWidth);
+        }
+
+        _ = elements.TryGetNonEnumeratedCount(out int count);
+        totalWidth += Math.Max(0, count - 1) * ColumnSpacing;
+        return totalWidth;
+    }
+
     internal void ColumnResized()
     {
         InvalidateArrange();
 
         foreach (var row in Rows)
         {
+            row.InvalidateMeasure();
             row.InvalidateArrange();
         }
     }

--- a/components/DataTable/src/DataTable/DataTable.cs
+++ b/components/DataTable/src/DataTable/DataTable.cs
@@ -31,8 +31,7 @@ public partial class DataTable : Panel
                 totalWidth += Math.Max(column.DesiredSize.Width, column.MaxChildDesiredWidth);
         }
 
-        _ = elements.TryGetNonEnumeratedCount(out int count);
-        totalWidth += Math.Max(0, count - 1) * ColumnSpacing;
+        totalWidth += Math.Max(0, elements.Count() - 1) * ColumnSpacing;
         return totalWidth;
     }
 


### PR DESCRIPTION
This should fix #645. 
- It adds `CalculateDesiredWidth()` to compute the total desired width, with spacing and returns that to the `DataTable`.
- Updates data table table to have horizontal scrolling


https://github.com/user-attachments/assets/cf34e8d9-9a43-463d-8e9c-43c643ef7896

https://github.com/user-attachments/assets/aa08adc7-751b-4c3f-8873-1878f24fd824
