### PR TITLE
Optimize DP setter codegen for Color, CornerRadius, and Thickness on WinAppSDK

### DIFF
--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
@@ -509,7 +509,7 @@ partial class DependencyPropertyGenerator
             }
 
             // UWP is not getting any new APIs in 'XamlBindingHelper', so if we didn't hit a match yet, we can stop here
-            if (!useWindowsUIXaml)
+            if (useWindowsUIXaml)
             {
                 return null;
             }

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
@@ -471,8 +471,10 @@ partial class DependencyPropertyGenerator
         /// Gets the <c>XamlBindingHelper.SetPropertyFrom*</c> method name for a given property type, if supported.
         /// </summary>
         /// <param name="typeSymbol">The input <see cref="ITypeSymbol"/> to check.</param>
+        /// <param name="useWindowsUIXaml">Whether to use the UWP XAML or WinUI 3 XAML namespaces.</param>
+        /// <param name="compilation">The <see cref="Compilation"/> for the current run, used to probe for optional APIs.</param>
         /// <returns>The method name to use, or <see langword="null"/> if the type is not supported.</returns>
-        public static string? GetXamlBindingHelperSetMethodName(ITypeSymbol typeSymbol)
+        public static string? GetXamlBindingHelperSetMethodName(ITypeSymbol typeSymbol, bool useWindowsUIXaml, Compilation compilation)
         {
             // Check for well known primitive types first (these are the most common)
             switch (typeSymbol.SpecialType)
@@ -491,13 +493,38 @@ partial class DependencyPropertyGenerator
                 default: break;
             }
 
-            // Check for the remaining well known WinRT projected types
+            // Check for the remaining well known WinRT projected types (always available on both UWP and WinAppSDK)
             if (typeSymbol.HasFullyQualifiedMetadataName("System.DateTimeOffset")) return "SetPropertyFromDateTime";
             if (typeSymbol.HasFullyQualifiedMetadataName("System.TimeSpan")) return "SetPropertyFromTimeSpan";
             if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Point")) return "SetPropertyFromPoint";
             if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Rect")) return "SetPropertyFromRect";
             if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Size")) return "SetPropertyFromSize";
             if (typeSymbol.HasFullyQualifiedMetadataName("System.Uri")) return "SetPropertyFromUri";
+
+            // The following types only have a corresponding 'SetPropertyFrom*' method on the WinAppSDK
+            // 'XamlBindingHelper'. The methods were also only added in newer WinAppSDK versions, so we
+            // additionally have to probe for their presence on the resolved type before emitting calls
+            // to them, to avoid breaking codegen for projects targeting older WinAppSDK releases.
+            if (!useWindowsUIXaml)
+            {
+                if (typeSymbol.HasFullyQualifiedMetadataName("Windows.UI.Color") &&
+                    HasXamlBindingHelperMethod(compilation, "SetPropertyFromColor", "Windows.UI.Color"))
+                {
+                    return "SetPropertyFromColor";
+                }
+
+                if (typeSymbol.HasFullyQualifiedMetadataName($"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.CornerRadius") &&
+                    HasXamlBindingHelperMethod(compilation, "SetPropertyFromCornerRadius", $"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.CornerRadius"))
+                {
+                    return "SetPropertyFromCornerRadius";
+                }
+
+                if (typeSymbol.HasFullyQualifiedMetadataName($"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.Thickness") &&
+                    HasXamlBindingHelperMethod(compilation, "SetPropertyFromThickness", $"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.Thickness"))
+                {
+                    return "SetPropertyFromThickness";
+                }
+            }
 
             return null;
         }

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
@@ -503,6 +503,53 @@ partial class DependencyPropertyGenerator
         }
 
         /// <summary>
+        /// Checks whether the WinAppSDK <c>XamlBindingHelper</c> type exposes a <c>SetPropertyFrom*</c> static method
+        /// with the expected <c>(object, DependencyProperty, T)</c> signature.
+        /// </summary>
+        /// <param name="compilation">The <see cref="Compilation"/> for the current run.</param>
+        /// <param name="methodName">The name of the static method to look for.</param>
+        /// <param name="valueTypeMetadataName">The fully qualified metadata name of the third (value) parameter.</param>
+        /// <returns>Whether the WinAppSDK <c>XamlBindingHelper</c> exposes a matching static method.</returns>
+        /// <remarks>
+        /// This helper intentionally hardcodes the WinAppSDK <c>XamlBindingHelper</c> type, as it is only used
+        /// to probe for methods that don't exist on the UWP equivalent. Callers must therefore gate on
+        /// <c>useWindowsUIXaml == false</c> before invoking it.
+        /// </remarks>
+        private static bool HasXamlBindingHelperMethod(Compilation compilation, string methodName, string valueTypeMetadataName)
+        {
+            INamedTypeSymbol? xamlBindingHelperType = compilation.GetTypeByMetadataName(WellKnownTypeNames.XamlBindingHelper(useWindowsUIXaml: false));
+
+            if (xamlBindingHelperType is null)
+            {
+                return false;
+            }
+
+            // Match the expected 'static void Method(object, DependencyProperty, T)' shape. We validate the
+            // exact parameter types to guard against any future overload with the same name but different shape.
+            foreach (ISymbol member in xamlBindingHelperType.GetMembers(methodName))
+            {
+                if (member is IMethodSymbol
+                    {
+                        IsStatic: true,
+                        ReturnsVoid: true,
+                        Parameters:
+                        [
+                            { Type.SpecialType: SpecialType.System_Object },
+                            { Type: INamedTypeSymbol dependencyPropertyType },
+                            { Type: INamedTypeSymbol valueType }
+                        ]
+                    } &&
+                    dependencyPropertyType.HasFullyQualifiedMetadataName(WellKnownTypeNames.DependencyProperty(useWindowsUIXaml: false)) &&
+                    valueType.HasFullyQualifiedMetadataName(valueTypeMetadataName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Gathers all forwarded attributes for the generated property.
         /// </summary>
         ///<param name="node">The input <see cref="PropertyDeclarationSyntax"/> node.</param>

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.Execute.cs
@@ -494,35 +494,39 @@ partial class DependencyPropertyGenerator
             }
 
             // Check for the remaining well known WinRT projected types (always available on both UWP and WinAppSDK)
-            if (typeSymbol.HasFullyQualifiedMetadataName("System.DateTimeOffset")) return "SetPropertyFromDateTime";
-            if (typeSymbol.HasFullyQualifiedMetadataName("System.TimeSpan")) return "SetPropertyFromTimeSpan";
-            if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Point")) return "SetPropertyFromPoint";
-            if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Rect")) return "SetPropertyFromRect";
-            if (typeSymbol.HasFullyQualifiedMetadataName("Windows.Foundation.Size")) return "SetPropertyFromSize";
-            if (typeSymbol.HasFullyQualifiedMetadataName("System.Uri")) return "SetPropertyFromUri";
+            foreach ((string fullyQualifiedName, string methodName) in (ReadOnlySpan<(string, string)>)[
+                ("System.DateTimeOffset", "SetPropertyFromDateTime"),
+                ("System.TimeSpan", "SetPropertyFromTimeSpan"),
+                ("Windows.Foundation.Point", "SetPropertyFromPoint"),
+                ("Windows.Foundation.Rect", "SetPropertyFromRect"),
+                ("Windows.Foundation.Size", "SetPropertyFromSize"),
+                ("System.Uri", "SetPropertyFromUri")])
+            {
+                if (typeSymbol.HasFullyQualifiedMetadataName(fullyQualifiedName))
+                {
+                    return methodName;
+                }
+            }
+
+            // UWP is not getting any new APIs in 'XamlBindingHelper', so if we didn't hit a match yet, we can stop here
+            if (!useWindowsUIXaml)
+            {
+                return null;
+            }
 
             // The following types only have a corresponding 'SetPropertyFrom*' method on the WinAppSDK
             // 'XamlBindingHelper'. The methods were also only added in newer WinAppSDK versions, so we
             // additionally have to probe for their presence on the resolved type before emitting calls
             // to them, to avoid breaking codegen for projects targeting older WinAppSDK releases.
-            if (!useWindowsUIXaml)
+            foreach ((string fullyQualifiedName, string methodName) in (ReadOnlySpan<(string, string)>)[
+                ("Windows.UI.Color", "SetPropertyFromColor"),
+                ("Microsoft.UI.Xaml.CornerRadius", "SetPropertyFromCornerRadius"),
+                ("Microsoft.UI.Xaml.Thickness", "SetPropertyFromThickness")])
             {
-                if (typeSymbol.HasFullyQualifiedMetadataName("Windows.UI.Color") &&
-                    HasXamlBindingHelperMethod(compilation, "SetPropertyFromColor", "Windows.UI.Color"))
+                if (typeSymbol.HasFullyQualifiedMetadataName(fullyQualifiedName) &&
+                    HasXamlBindingHelperMethod(compilation, methodName, fullyQualifiedName))
                 {
-                    return "SetPropertyFromColor";
-                }
-
-                if (typeSymbol.HasFullyQualifiedMetadataName($"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.CornerRadius") &&
-                    HasXamlBindingHelperMethod(compilation, "SetPropertyFromCornerRadius", $"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.CornerRadius"))
-                {
-                    return "SetPropertyFromCornerRadius";
-                }
-
-                if (typeSymbol.HasFullyQualifiedMetadataName($"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.Thickness") &&
-                    HasXamlBindingHelperMethod(compilation, "SetPropertyFromThickness", $"{WellKnownTypeNames.MicrosoftUIXamlNamespace}.Thickness"))
-                {
-                    return "SetPropertyFromThickness";
+                    return methodName;
                 }
             }
 

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.cs
@@ -110,7 +110,10 @@ public sealed partial class DependencyPropertyGenerator : IIncrementalGenerator
                     // Get the optimized XamlBindingHelper method name for the property type, if applicable.
                     // This is only used when the property type is not 'object' (which would gain nothing),
                     // and the user hasn't provided their own 'On<PROPERTY_NAME>Set(ref object)' implementation.
-                    string? xamlBindingHelperSetMethodName = Execute.GetXamlBindingHelperSetMethodName(propertySymbol.Type);
+                    string? xamlBindingHelperSetMethodName = Execute.GetXamlBindingHelperSetMethodName(
+                        propertySymbol.Type,
+                        useWindowsUIXaml,
+                        context.SemanticModel.Compilation);
 
                     if (xamlBindingHelperSetMethodName is not null)
                     {

--- a/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.cs
+++ b/components/DependencyPropertyGenerator/CommunityToolkit.DependencyPropertyGenerator.SourceGenerators/DependencyPropertyGenerator.cs
@@ -111,9 +111,9 @@ public sealed partial class DependencyPropertyGenerator : IIncrementalGenerator
                     // This is only used when the property type is not 'object' (which would gain nothing),
                     // and the user hasn't provided their own 'On<PROPERTY_NAME>Set(ref object)' implementation.
                     string? xamlBindingHelperSetMethodName = Execute.GetXamlBindingHelperSetMethodName(
-                        propertySymbol.Type,
-                        useWindowsUIXaml,
-                        context.SemanticModel.Compilation);
+                        typeSymbol: propertySymbol.Type,
+                        useWindowsUIXaml: useWindowsUIXaml,
+                        compilation: context.SemanticModel.Compilation);
 
                     if (xamlBindingHelperSetMethodName is not null)
                     {


### PR DESCRIPTION
Follow-up to the previous `XamlBindingHelper`-based DP setter optimizations.

The latest version of WinAppSDK exposes three new static methods on `Microsoft.UI.Xaml.Markup.XamlBindingHelper`:

- `SetPropertyFromColor(object, DependencyProperty, Windows.UI.Color)`
- `SetPropertyFromCornerRadius(object, DependencyProperty, Microsoft.UI.Xaml.CornerRadius)`
- `SetPropertyFromThickness(object, DependencyProperty, Microsoft.UI.Xaml.Thickness)`

These extend the optimized setter path the generator already uses for other well-known WinRT-projected types, but they (1) only exist on WinAppSDK (the UWP `Windows.UI.Xaml.Markup.XamlBindingHelper` has no equivalent) and (2) were only added in a recent WinAppSDK release. Consumers on older WinAppSDK versions must therefore not get codegen that calls them.

## What changed

- `Execute.GetXamlBindingHelperSetMethodName` now takes the current `Compilation` and the `useWindowsUIXaml` flag so it can probe the resolved `XamlBindingHelper` type for the new methods.
- A new private `Execute.HasXamlBindingHelperMethod` helper resolves `Microsoft.UI.Xaml.Markup.XamlBindingHelper` (via `WellKnownTypeNames.XamlBindingHelper(useWindowsUIXaml: false)`) and verifies the full `static void Method(object, DependencyProperty, T)` shape, where `T` matches a caller-supplied metadata name. The strict signature check guards against any future overload with the same name but a different shape.
- The well-known type-to-method tables are consolidated into two `ReadOnlySpan<(string, string)>` literals — one for the methods available on both UWP and WinAppSDK, and one for the new WinAppSDK-only methods. UWP short-circuits before the second loop, so no `GetTypeByMetadataName` work happens on the UWP path.
- The single call site in `DependencyPropertyGenerator.cs` flows `useWindowsUIXaml` and `context.SemanticModel.Compilation` to the helper using named arguments.

## Correctness / incremental notes

- UWP (`useWindowsUIXaml == true`) is left completely untouched — the new code is gated behind `!useWindowsUIXaml`, and existing snapshot tests (which target UWP) are unaffected.
- The probe runs inside the existing `ForAttributeWithMetadataNameAndOptions` transform, which already takes a non-equatable `GeneratorAttributeSyntaxContext` and produces equatable output. The resulting method name flows through the existing equatable `DependencyPropertyInfo.XamlBindingHelperSetMethodName` string, so downstream output correctly invalidates when a project upgrades its WinAppSDK reference.
- `Compilation.GetTypeByMetadataName` is internally cached, and the probe only runs after the property type already matches one of the three new metadata names, so the per-property overhead is negligible.

## Tests

No new tests are added: the new behavior depends on whether the host compilation references a WinAppSDK version that exposes these methods, and that cannot easily be toggled inside the existing snapshot test infrastructure. The change is purely additive on the WinAppSDK code path and leaves UWP/`useWindowsUIXaml == true` codegen unchanged, so existing test assertions continue to hold.