### PR TITLE
Upgraded testspace to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Install Testspace Module
         if: ${{ env.HAS_BUILDABLE_COMPONENTS == 'true' }}
-        uses: testspace-com/setup-testspace@v1
+        uses: testspace-com/setup-testspace@v1.0.8
         with:
           domain: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Background

Testspace has been stalling and blocking the merge of several PRs, specifically observed [#847](https://github.com/CommunityToolkit/Windows/pull/847), [#855](https://github.com/CommunityToolkit/Windows/pull/855), [#576](https://github.com/CommunityToolkit/Windows/pull/576). 

Investigation into the exact root cause of these failures is still ongoing. 

## Problem

During investigation, we noticed that the version number was out of date. The current latest version as of writing is https://github.com/testspace-com/setup-testspace/releases/tag/v1.0.8

## Solution

This PR updates our CI to the latest version. 
